### PR TITLE
Make pyflyby compatible with python3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 build
 dist
 pytestdebug.log
+__pycache__

--- a/conftest.py
+++ b/conftest.py
@@ -25,10 +25,10 @@ def pytest_runtest_setup(item):
 
 def pytest_report_header(config):
     import IPython
-    print "IPython %s" % (IPython.__version__)
+    print("IPython %s" % (IPython.__version__))
     import pyflyby
     dir = os.path.dirname(pyflyby.__file__)
-    print "pyflyby %s from %s" % (pyflyby.__version__, dir)
+    print("pyflyby %s from %s" % (pyflyby.__version__, dir))
 
 
 def _setup_logger():
@@ -92,7 +92,7 @@ else:
     pylib = os.path.join(PYFLYBY_HOME, "lib/python")
     sys.path.insert(0, pylib)
     os.environ["PYTHONPATH"] = ":".join(
-        [pylib] + filter(None, os.environ.get("PYTHONPATH", "").split(":")))
+        [pylib] + list(filter(None, os.environ.get("PYTHONPATH", "").split(":"))))
     import pyflyby
 
     fn = re.sub("[.]py[co]$", ".py", pyflyby.__file__)

--- a/lib/python/pyflyby/__init__.py
+++ b/lib/python/pyflyby/__init__.py
@@ -42,7 +42,7 @@ from   pyflyby._dbg             import (breakpoint, debug_exception,
 
 # Promote the function & classes that we've chosen to expose publicly to be
 # known as pyflyby.Foo instead of pyflyby._module.Foo.
-for x in globals().values():
+for x in list(globals().values()):
     if getattr(x, "__module__", "").startswith("pyflyby."):
         x.__module__ = "pyflyby"
 del x

--- a/lib/python/pyflyby/_autoimp.py
+++ b/lib/python/pyflyby/_autoimp.py
@@ -713,7 +713,7 @@ def _find_loads_without_stores_in_code(co, loads_without_stores):
             i = i+2
             if op == EXTENDED_ARG:
                 if six.PY2:
-                    extended_arg = oparg*65536L
+                    extended_arg = oparg*long(65536)
                 else:
                     extended_arg = oparg*65536
                 continue

--- a/lib/python/pyflyby/_dbg.py
+++ b/lib/python/pyflyby/_dbg.py
@@ -13,6 +13,7 @@ from   functools                import wraps
 import os
 import pwd
 import signal
+import six
 import sys
 import time
 from   types                    import CodeType, FrameType, TracebackType
@@ -290,7 +291,7 @@ def _debug_code(arg, globals=None, locals=None, auto_import=True, tty="/dev/tty"
         print("Entering debugger.  Use 'n' to step, 'c' to run, 'q' to stop.")
         print("")
         from ._parse import PythonStatement, PythonBlock, FileText
-        if isinstance(arg, (basestring, PythonStatement, PythonBlock, FileText)):
+        if isinstance(arg, (six.string_types, PythonStatement, PythonBlock, FileText)):
             # Compile the block so that we can get the right compile mode.
             arg = PythonBlock(arg)
             # TODO: enter text into linecache
@@ -440,7 +441,7 @@ def debugger(*args, **kwargs):
             # TODO: capture globals/locals when relevant.
             wait_for_debugger_to_attach(arg)
             return
-    if isinstance(arg, (basestring, PythonStatement, PythonBlock, FileText,
+    if isinstance(arg, (six.string_types, PythonStatement, PythonBlock, FileText,
                         CodeType, Callable)):
         _debug_code(arg, globals=globals, locals=locals, tty=tty)
         on_continue()
@@ -904,12 +905,12 @@ def inject(pid, statements, wait=True, show_gdb_output=False):
     """
     import subprocess
     os.kill(pid, 0) # raises OSError "No such process" unless pid exists
-    if isinstance(statements, basestring):
+    if isinstance(statements, six.string_types):
         statements = (statements,)
     else:
         statements = tuple(statements)
     for statement in statements:
-        if not isinstance(statement, basestring):
+        if not isinstance(statement, six.string_types):
             raise TypeError(
                 "Expected iterable of strings, not %r" % (type(statement),))
     # Based on

--- a/lib/python/pyflyby/_docxref.py
+++ b/lib/python/pyflyby/_docxref.py
@@ -28,7 +28,7 @@ from __future__ import absolute_import, division, with_statement
 
 import re
 import six
-from   six                      import builtins
+from   six.moves                import builtins
 from   textwrap                 import dedent
 
 from   epydoc.apidoc            import (ClassDoc, ModuleDoc, PropertyDoc,

--- a/lib/python/pyflyby/_docxref.py
+++ b/lib/python/pyflyby/_docxref.py
@@ -26,8 +26,9 @@
 
 from __future__ import absolute_import, division, with_statement
 
-import __builtin__
 import re
+import six
+from   six                      import builtins
 from   textwrap                 import dedent
 
 from   epydoc.apidoc            import (ClassDoc, ModuleDoc, PropertyDoc,
@@ -290,7 +291,7 @@ class XrefScanner(object):
         Look in modules that we weren't explicitly asked to look in, if
         needed.
         """
-        if identifier in __builtin__.__dict__:
+        if identifier in builtins.__dict__:
             return True
         def check_container():
             if self.expanded_docindex.find(identifier, container) is not None:
@@ -348,7 +349,7 @@ class XrefScanner(object):
             return ''
 
         def scan_tree(tree):
-            if isinstance(tree, basestring):
+            if isinstance(tree, six.string_types):
                 return tree
             variables = [scan_tree(child) for child in tree.children]
             if tree.tag == 'link':

--- a/lib/python/pyflyby/_file.py
+++ b/lib/python/pyflyby/_file.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, with_statement
 
 import os
 import re
+import six
 import sys
 
 from   pyflyby._util            import cached_attribute, memoize
@@ -27,13 +28,13 @@ class Filename(object):
     def __new__(cls, arg):
         if isinstance(arg, cls):
             return arg
-        if isinstance(arg, basestring):
+        if isinstance(arg, six.string_types):
             return cls._from_filename(arg)
         raise TypeError
 
     @classmethod
     def _from_filename(cls, filename):
-        if not isinstance(filename, basestring):
+        if not isinstance(filename, six.string_types):
             raise TypeError
         filename = str(filename)
         if not filename:
@@ -308,6 +309,18 @@ class FilePos(object):
             return NotImplemented
         return cmp(self._data, other._data)
 
+    def __lt__(self, other):
+        if self is other:
+            return 0
+        if not isinstance(other, FilePos):
+            return NotImplemented
+        return self._data < other._data
+
+    def __le__(self, other):
+        if not isinstance(other, FilePos):
+            return NotImplemented
+        return self._data <= other._data
+
     def __hash__(self):
         return hash(self._data)
 
@@ -352,7 +365,7 @@ class FileText(object):
             return cls(read_file(arg), filename=filename, startpos=startpos)
         elif hasattr(arg, "__text__"):
             return FileText(arg.__text__(), filename=filename, startpos=startpos)
-        elif isinstance(arg, basestring):
+        elif isinstance(arg, six.string_types):
             self = object.__new__(cls)
             self.joined = arg
         else:

--- a/lib/python/pyflyby/_flags.py
+++ b/lib/python/pyflyby/_flags.py
@@ -7,6 +7,8 @@ from __future__ import absolute_import, division, with_statement
 import __future__
 import ast
 import operator
+import six
+from   six.moves                import reduce
 
 from   pyflyby._util            import cached_attribute
 
@@ -67,7 +69,7 @@ class CompilerFlags(int):
                 return cls._ZERO
             elif isinstance(arg, int):
                 return cls.from_int(arg)
-            elif isinstance(arg, basestring):
+            elif isinstance(arg, six.string_types):
                 return cls.from_str(arg)
             elif isinstance(arg, ast.AST):
                 return cls.from_ast(arg)

--- a/lib/python/pyflyby/_format.py
+++ b/lib/python/pyflyby/_format.py
@@ -4,6 +4,8 @@
 
 from __future__ import absolute_import, division, with_statement
 
+import six
+
 
 class FormatParams(object):
     max_line_length = 79
@@ -26,7 +28,7 @@ class FormatParams(object):
         if kwargs:
             dicts.append(kwargs)
         for kwargs in dicts:
-            for key, value in kwargs.iteritems():
+            for key, value in six.iteritems(kwargs):
                 if hasattr(self, key):
                     setattr(self, key, value)
                 else:

--- a/lib/python/pyflyby/_idents.py
+++ b/lib/python/pyflyby/_idents.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, with_statement
 
 from   keyword                  import kwlist
 import re
+import six
 
 from   pyflyby._util            import cached_attribute
 
@@ -13,7 +14,8 @@ from   pyflyby._util            import cached_attribute
 # Don't consider "print" a keyword, in order to be compatible with user code
 # that uses "from __future__ import print_function".
 _my_kwlist = list(kwlist)
-_my_kwlist.remove("print")
+if six.PY2:
+    _my_kwlist.remove("print")
 _my_iskeyword = frozenset(_my_kwlist).__contains__
 
 
@@ -110,7 +112,7 @@ def is_identifier(s, dotted=False, prefix=False):
     @rtype:
       C{bool}
     """
-    if not isinstance(s, basestring):
+    if not isinstance(s, six.string_types):
         raise TypeError("is_identifier(): expected a string; got a %s"
                         % (type(s).__name__,))
     if prefix:
@@ -155,7 +157,7 @@ class DottedIdentifier(object):
     def __new__(cls, arg):
         if isinstance(arg, cls):
             return arg
-        if isinstance(arg, basestring):
+        if isinstance(arg, six.string_types):
             return cls._from_name(arg)
         if isinstance(arg, (tuple, list)):
             return cls._from_name(".".join(arg))

--- a/lib/python/pyflyby/_importclns.py
+++ b/lib/python/pyflyby/_importclns.py
@@ -5,6 +5,7 @@
 from __future__ import absolute_import, division, with_statement
 
 from   collections              import defaultdict
+import six
 
 from   pyflyby._flags           import CompilerFlags
 from   pyflyby._idents          import dotted_prefixes, is_identifier
@@ -227,7 +228,7 @@ class ImportSet(object):
                 frm_imports[module_name].add(imp)
         return tuple(
             dict( (k, frozenset(v))
-                  for k, v in imports.iteritems())
+                  for k, v in six.iteritems(imports))
             for imports in [ftr_imports, pkg_imports, frm_imports])
 
     def get_statements(self, separate_from_imports=True):
@@ -260,7 +261,7 @@ class ImportSet(object):
             def union_dicts(*dicts):
                 result = {}
                 for label, dict in enumerate(dicts):
-                    for k, v in dict.iteritems():
+                    for k, v in six.iteritems(dict):
                         result[(k, label)] = v
                 return result
             groups = [groups[0], union_dicts(*groups[1:])]
@@ -316,7 +317,7 @@ class ImportSet(object):
         for imp in self._importset:
             d[imp.import_as].append(imp)
         return dict( (k, tuple(sorted(stable_unique(v))))
-                     for k, v in d.iteritems() )
+                     for k, v in six.iteritems(d) )
 
     @cached_attribute
     def member_names(self):
@@ -346,7 +347,7 @@ class ImportSet(object):
                 splt = prefix.rsplit(".", 1)
                 d[splt[0]].add(splt[1])
         return dict( (k, tuple(sorted(v)))
-                     for k, v in d.iteritems() )
+                     for k, v in six.iteritems(d) )
 
     @cached_attribute
     def conflicting_imports(self):
@@ -364,7 +365,7 @@ class ImportSet(object):
         """
         return tuple(
             k
-            for k, v in self.by_import_as.iteritems()
+            for k, v in six.iteritems(self.by_import_as)
             if len(v) > 1 and k != "*")
 
     @cached_attribute
@@ -558,10 +559,10 @@ class ImportMap(object):
         return self._data.items()
 
     def iteritems(self):
-        return self._data.iteritems()
+        return six.iteritems(self._data)
 
     def iterkeys(self):
-        return self._data.iterkeys()
+        return six.iterkeys(self._data)
 
     def keys(self):
         return self._data.keys()

--- a/lib/python/pyflyby/_importdb.py
+++ b/lib/python/pyflyby/_importdb.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, division, with_statement
 from   collections              import defaultdict
 import os
 import re
+import six
 
 from   pyflyby._file            import Filename, expand_py_files_from_args
 from   pyflyby._idents          import dotted_prefixes
@@ -39,7 +40,7 @@ def _get_env_var(env_var_name, default):
     '''
     assert re.match("^[A-Z_]+$", env_var_name)
     assert isinstance(default, (tuple, list))
-    value = filter(None, os.environ.get(env_var_name, '').split(':'))
+    value = list(filter(None, os.environ.get(env_var_name, '').split(':')))
     if not value:
         return default
     # Replace '-' with C{default}
@@ -496,27 +497,27 @@ class ImportDB(object):
 
     @classmethod
     def _parse_import_set(cls, arg):
-        if isinstance(arg, basestring):
+        if isinstance(arg, six.string_types):
             arg = [arg]
         if not isinstance(arg, (tuple, list)):
             raise ValueError("Expected a list, not a %s" % (type(arg).__name__,))
         for item in arg:
-            if not isinstance(item, basestring):
+            if not isinstance(item, six.string_types):
                 raise ValueError(
                     "Expected a list of str, not %s" % (type(item).__name__,))
         return ImportSet(arg)
 
     @classmethod
     def _parse_import_map(cls, arg):
-        if isinstance(arg, basestring):
+        if isinstance(arg, six.string_types):
             arg = [arg]
         if not isinstance(arg, dict):
             raise ValueError("Expected a dict, not a %s" % (type(arg).__name__,))
         for k, v in arg.items():
-            if not isinstance(k, basestring):
+            if not isinstance(k, six.string_types):
                 raise ValueError(
                     "Expected a dict of str, not %s" % (type(k).__name__,))
-            if not isinstance(v, basestring):
+            if not isinstance(v, six.string_types):
                 raise ValueError(
                     "Expected a dict of str, not %s" % (type(v).__name__,))
         return ImportMap(arg)
@@ -552,7 +553,7 @@ class ImportDB(object):
             for prefix in dotted_prefixes(imp.fullname)[:-1]:
                 d[prefix].add(Import.from_parts(prefix, prefix))
         return dict( (k, tuple(sorted(v - set(self.forget_imports.imports))))
-                     for k, v in d.iteritems())
+                     for k, v in six.iteritems(d))
 
     def __repr__(self):
         printed = self.pretty_print()

--- a/lib/python/pyflyby/_importstmt.py
+++ b/lib/python/pyflyby/_importstmt.py
@@ -290,6 +290,13 @@ class Import(object):
             return NotImplemented
         return cmp(self._data, other._data)
 
+    def __lt__(self, other):
+        if self is other:
+            return 0
+        if not isinstance(other, Import):
+            return NotImplemented
+        return self._data < other._data
+
 
 class ImportStatement(object):
     """

--- a/lib/python/pyflyby/_modules.py
+++ b/lib/python/pyflyby/_modules.py
@@ -6,6 +6,8 @@ from __future__ import absolute_import, division, with_statement
 
 import os
 import re
+import six
+from   six                      import reraise
 import sys
 import types
 
@@ -63,13 +65,13 @@ def import_module(module_name):
                      real_importerror1, real_importerror2, real_importerror3)
         if real_importerror1 and real_importerror2 and real_importerror3:
             raise
-        raise ErrorDuringImportError(
+        reraise(ErrorDuringImportError(
             "Error while attempting to import %s: %s: %s"
-            % (module_name, type(e).__name__, e)), None, sys.exc_info()[2]
+            % (module_name, type(e).__name__, e)), None, sys.exc_info()[2])
     except Exception as e:
-        raise ErrorDuringImportError(
+        reraise(ErrorDuringImportError(
             "Error while attempting to import %s: %s: %s"
-            % (module_name, type(e).__name__, e)), None, sys.exc_info()[2]
+            % (module_name, type(e).__name__, e)), None, sys.exc_info()[2])
 
 
 def _my_iter_modules(path, prefix=''):
@@ -124,7 +126,7 @@ class ModuleHandle(object):
             return arg
         if isinstance(arg, Filename):
             return cls._from_filename(arg)
-        if isinstance(arg, (basestring, DottedIdentifier)):
+        if isinstance(arg, (six.string_types, DottedIdentifier)):
             return cls._from_modulename(arg)
         if isinstance(arg, types.ModuleType):
             return cls._from_module(arg)

--- a/lib/python/pyflyby/_py.py
+++ b/lib/python/pyflyby/_py.py
@@ -301,12 +301,13 @@ $ py                                       IPython shell
 
 # TODO: add --profile, --runsnake
 
-import __builtin__
 import ast
 from   contextlib               import contextmanager
 import inspect
 import os
 import re
+import six
+from   six                      import builtins
 import sys
 import types
 from   types                    import FunctionType, MethodType
@@ -314,10 +315,10 @@ from   types                    import FunctionType, MethodType
 from   pyflyby._autoimp         import auto_import, find_missing_imports
 from   pyflyby._cmdline         import print_version_and_exit, syntax
 from   pyflyby._dbg             import (add_debug_functions_to_builtins,
-                                        attach_debugger, debugger,
-                                        enable_faulthandler,
-                                        enable_sigterm_handler,
+                                        attach_debugger, debug_statement,
+                                        debugger, enable_faulthandler,
                                         enable_signal_handler_debugger,
+                                        enable_sigterm_handler,
                                         remote_print_stack)
 from   pyflyby._file            import Filename, UnsafeFilenameError, which
 from   pyflyby._flags           import CompilerFlags
@@ -584,7 +585,7 @@ class UserExpr(object):
             if source is not None:
                 raise ValueError(
                     "UserExpr(): source argument not allowed for auto")
-            if not isinstance(arg, basestring):
+            if not isinstance(arg, six.string_types):
                 raise ValueError(
                     "UserExpr(): arg must be a string if arg_mode='auto'")
             self._original_arg_as_source = PythonBlock(arg, flags=FLAGS)
@@ -1316,8 +1317,8 @@ class _Namespace(object):
 
     def __init__(self):
         self.globals      = {"__name__": "__main__",
-                             "__builtin__": __builtin__,
-                             "__builtins__": __builtin__}
+                             "__builtin__": builtins,
+                             "__builtins__": builtins}
         self.autoimported = {}
 
     def auto_import(self, arg):

--- a/lib/python/pyflyby/_py.py
+++ b/lib/python/pyflyby/_py.py
@@ -307,7 +307,7 @@ import inspect
 import os
 import re
 import six
-from   six                      import builtins
+from   six.moves                import builtins
 import sys
 import types
 from   types                    import FunctionType, MethodType

--- a/tests/test_importclns.py
+++ b/tests/test_importclns.py
@@ -23,7 +23,7 @@ def test_ImportSet_1():
         Import("from m1 import f3"),
         Import("from m2 import f1"),
         Import("from m3 import m4 as m34"))
-    print importset.imports
+    print(importset.imports)
     assert importset.imports == expected
     assert len(importset) == 5
 
@@ -108,7 +108,7 @@ def test_ImportSet_ignore_shadowed_1():
         Import("from m3 import f3"),
         Import("from m3 import f6"),
     )
-    print importset.imports
+    print(importset.imports)
     assert importset.imports == expected
     assert len(importset) == 6
 

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -7,7 +7,6 @@ from __future__ import absolute_import, division, with_statement
 
 import IPython
 import atexit
-from   cStringIO                import StringIO
 from   contextlib               import contextmanager
 import difflib
 from   functools                import wraps
@@ -21,6 +20,8 @@ import re
 import readline
 import requests
 from   shutil                   import rmtree
+import six
+from   six.moves                import cStringIO as StringIO
 import signal
 from   subprocess               import PIPE, Popen, check_call
 import sys
@@ -453,7 +454,7 @@ def _build_pythonpath(PYTHONPATH):
     """
     pypath = [os.path.dirname(os.path.dirname(pyflyby.__file__))]
     pypath += _extra_readline_pythonpath_dirs()
-    if isinstance(PYTHONPATH, (Filename, basestring)):
+    if isinstance(PYTHONPATH, (Filename, six.string_types)):
         PYTHONPATH = [PYTHONPATH]
     PYTHONPATH = [str(Filename(d)) for d in PYTHONPATH]
     pypath += PYTHONPATH
@@ -493,7 +494,7 @@ def _build_ipython_cmd(ipython_dir, prog="ipython", args=[], autocall=False):
             cmd += ['jupyter']
         else:
             cmd += ['ipython']
-    if isinstance(args, basestring):
+    if isinstance(args, six.string_types):
         args = [args]
     if args and not args[0].startswith("-"):
         app = args[0]
@@ -741,7 +742,7 @@ def ipython(template, **kwargs):
     template = template.format(**parent_vars)
     input, expected = parse_template(template)
     args = kwargs.pop("args", ())
-    if isinstance(args, basestring):
+    if isinstance(args, six.string_types):
         args = [args]
     args = list(args)
     if args and not args[0].startswith("-"):

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -101,8 +101,8 @@ def retry(exceptions=(Exception,), tries=5, delay=1.0, backoff=1.0):
                 try:
                     return f(*args, **kwargs)
                 except exceptions as e:
-                    print "Error: %s: %s; retrying in %.1f seconds" % (
-                        type(e).__name__, e, mdelay)
+                    print("Error: %s: %s; retrying in %.1f seconds" % (
+                        type(e).__name__, e, mdelay))
                     time.sleep(mdelay)
                     mtries -= 1
                     mdelay *= backoff
@@ -672,10 +672,10 @@ def IPythonCtx(prog="ipython",
         child.ipython_dir = ipython_dir
         yield child
     except (pexpect.ExceptionPexpect) as e:
-        print "Error: %s" % (e.__class__.__name__,)
-        print "Output so far:"
+        print("Error: %s" % (e.__class__.__name__,))
+        print("Output so far:")
         result = _clean_ipython_output(output.getvalue())
-        print ''.join("    %s\n"%line for line in result.splitlines())
+        print(''.join("    %s\n"%line for line in result.splitlines()))
         # Re-raise an exception wrapped so that we don't re-catch it for the
         # wrong child.
         raise ExpectError(e, child) #, None, sys.exc_info()[2]
@@ -778,13 +778,13 @@ def ipython(template, **kwargs):
     if kernel is not None:
         args += kernel.kernel_info
         kwargs.setdefault("ipython_dir", kernel.ipython_dir)
-    print "Input:"
-    print "".join("    %s\n"%line for line in input.splitlines())
+    print("Input:")
+    print("".join("    %s\n"%line for line in input.splitlines()))
     with IPythonCtx(args=args, **kwargs) as child:
         result = _interact_ipython(child, input, exitstr=exitstr,
                                    sendeof=sendeof, waiteof=waiteof)
-    print "Output:"
-    print "".join("    %s\n"%line for line in result.splitlines())
+    print("Output:")
+    print("".join("    %s\n"%line for line in result.splitlines()))
     assert_match(result, expected, ignore_prompt_number=ignore_prompt_number)
 
 

--- a/tests/test_py.py
+++ b/tests/test_py.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import, division, with_statement
 import os
 import pytest
 from   shutil                   import rmtree
+import six
 import subprocess
 import sys
 import tempfile
@@ -27,7 +28,7 @@ PYFLYBY_PATH = PYFLYBY_HOME / "etc/pyflyby"
 def flatten(args):
     result = []
     for arg in args:
-        if isinstance(arg, basestring):
+        if isinstance(arg, six.string_types):
             result.append(arg)
         else:
             try:


### PR DESCRIPTION
Changes to make pyflyby compatible with python 3.

This is WIP. @quarl, can you please create a new branch for this in pyflyby repository to ease code review and once changes are complete, we can merge the code back to master branch?

Issues to be fixed:
1. pyflyby._importclns.ConflictingImportsError: Refusing to pretty-print because of conflicting imports: ['__future__.division', '__future__.division'] imported as 'division'; ['__future__.absolute_import', '__future__.absolute_import'] imported as 'absolute_import'

2. Tab completion messes up the output in ipython 5.8 version in python 3. This is the same issue which is on todo for spyder.