### PR TITLE
Remove strict=False kwarg from without_imports()

### DIFF
--- a/bin/collect-imports
+++ b/bin/collect-imports
@@ -50,7 +50,7 @@ def main():
         importset = ImportSet([imp for imp in importset if match(imp)])
     if options.ignore_known:
         db = ImportDB.get_default(".")
-        importset = importset.without_imports(db.known_imports, strict=False)
+        importset = importset.without_imports(db.known_imports)
     sys.stdout.write(importset.pretty_print(
             allow_conflicts=True, params=options.params))
 


### PR DESCRIPTION
This argument was removed in https://github.com/pyflyby/pyflyby/commit/db3ca74d2bd5bc58d8887ef479a5f65c7160e1d8, removing it from CLI scripts.