### PR TITLE
Set up Travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
 
 install:
   - set -e
-  - pip install "pexpect>=3.3" pyflakes pytest epydoc rlipython
+  - pip install "pexpect>=3.3" pyflakes pytest epydoc rlipython requests
 
 script:
   - set -e

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ matrix:
       sudo: true
 
 install:
+  - set -e
   - pip install "pexpect>=3.3" pyflakes pytest epydoc rlipython
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: python
+
+sudo: false
+python:
+  - 2.7
+
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial
+      sudo: true
+
+  allow_failures:
+    - python: 3.7
+      dist: xenial
+      sudo: true
+
+install:
+  - pip install "pyexpect>=3.3" pyflakes pytest epydoc rlipython
+
+script:
+  - set -e
+  - set -x
+  - pytest --doctest-modules lib tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
 
 matrix:
   include:
+    - python: 2.7
     - python: 3.7
       dist: xenial
       sudo: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
       sudo: true
 
 install:
-  - pip install "pyexpect>=3.3" pyflakes pytest epydoc rlipython
+  - pip install "pexpect>=3.3" pyflakes pytest epydoc rlipython
 
 script:
   - set -e

--- a/setup.py
+++ b/setup.py
@@ -192,7 +192,7 @@ setup(
         "Programming Language :: Python",
     ],
     install_requires=['pyflakes'],
-    tests_require=['pexpect>=3.3', 'pytest', 'epydoc'],
+    tests_require=['pexpect>=3.3', 'pytest', 'epydoc', 'rlipython', 'requests'],
     cmdclass = {
         'test'           : PyTest,
         'collect_imports': CollectImports,


### PR DESCRIPTION
Someone with admin privileges in this repo should go to https://travis-ci.com/organizations/pyflyby/repositories and enable Travis testing for this repo. 

There are some test failures here. It may be better to try to fix those in a separate PR. 

I've also included Python 3.7 in the build matrix (as an allowed failure), so we can track the progress of it. 