### PR TITLE
Correctly handle scopes for function parameters

### DIFF
--- a/lib/python/pyflyby/_autoimp.py
+++ b/lib/python/pyflyby/_autoimp.py
@@ -6,7 +6,7 @@ from __future__ import (absolute_import, division, print_function,
                         with_statement)
 
 import ast
-from collections.abc import Sequence
+from collections import Sequence
 import contextlib
 import copy
 import sys

--- a/tests/test_autoimp.py
+++ b/tests/test_autoimp.py
@@ -242,6 +242,19 @@ def test_find_missing_imports_function_paramlist_1():
     assert expected == result
 
 
+def test_find_missing_imports_function_paramlist_2():
+    code = dedent("""
+        from somewhere import given, data
+
+        @given(data())
+        def blargh(data):
+            pass
+    """)
+    result  = find_missing_imports(code, [{}])
+    result  = _dilist2strlist(result)
+    expected = []
+    assert expected == result
+
 def test_find_missing_imports_function_defaults_1():
     code = dedent("""
         e = 1


### PR DESCRIPTION

The parameter names should be treated as Stores inside the function scope, and
the defaults should be treated as Loads from one scope up.

Fixes #34.
