### PR TITLE
Correctly handle keyword-only arguments with a default

### DIFF
--- a/lib/python/pyflyby/_autoimp.py
+++ b/lib/python/pyflyby/_autoimp.py
@@ -547,7 +547,9 @@ class _MissingImportFinder(object):
         # defined before the def).
         self.visit(node.defaults)
         if PY3:
-            self.visit(node.kw_defaults)
+            for i in node.kw_defaults:
+                if i:
+                    self.visit(i)
         # Store arg names.
         self.visit(node.args)
         if PY3:

--- a/tests/test_autoimp.py
+++ b/tests/test_autoimp.py
@@ -871,6 +871,33 @@ def test_find_missing_imports_keyword_only_args_1():
 @pytest.mark.skipif(
     PY2,
     reason="Python 3-only syntax.")
+def test_find_missing_imports_keyword_only_args_2():
+    code = dedent("""
+        def func(*args, kwonly):
+            a = kwonly
+    """)
+    result   = find_missing_imports(code, [{}])
+    result   = _dilist2strlist(result)
+    expected = []
+    assert expected == result
+
+
+@pytest.mark.skipif(
+    PY2,
+    reason="Python 3-only syntax.")
+def test_find_missing_imports_keyword_only_args_3():
+    code = dedent("""
+        def func(*args, kwonly, kwonly2=b):
+            a = kwonly
+    """)
+    result   = find_missing_imports(code, [{}])
+    result   = _dilist2strlist(result)
+    expected = ['b']
+    assert expected == result
+
+@pytest.mark.skipif(
+    PY2,
+    reason="Python 3-only syntax.")
 def test_find_missing_imports_annotations_1():
     code = dedent("""
         def func(a: b) -> c:


### PR DESCRIPTION
Fixes #41.

An alternate fix would be to allow `None` in `visit`. That would remove a lot of `if` checks in the visitor functions, but I'm not sure if wasn't included there for a reason. 