### PR TITLE
Epytext to reST

### DIFF
--- a/lib/python/pyflyby/_autoimp.py
+++ b/lib/python/pyflyby/_autoimp.py
@@ -33,9 +33,9 @@ _builtins2 = {"__file__": None}
 
 class ScopeStack(tuple):
     """
-    A stack of namespace scopes, as a tuple of C{dict}s.
+    A stack of namespace scopes, as a tuple of ``dict`` s.
 
-    Each entry is a C{dict}.
+    Each entry is a ``dict``.
 
     Ordered from most-global to most-local.
     Builtins are always included.
@@ -46,14 +46,14 @@ class ScopeStack(tuple):
 
     def __new__(cls, arg):
         """
-        Interpret argument as a C{ScopeStack}.
+        Interpret argument as a ``ScopeStack``.
 
-        @type arg:
-          C{ScopeStack}, C{dict}, C{list} of C{dict}
-        @param arg:
+        :type arg:
+          ``ScopeStack``, ``dict``, ``list`` of ``dict``
+        :param arg:
           Input namespaces
-        @rtype:
-          C{ScopeStack}
+        :rtype:
+          ``ScopeStack``
         """
         if isinstance(arg, ScopeStack):
             return arg
@@ -84,14 +84,14 @@ class ScopeStack(tuple):
 
     def with_new_scope(self, include_class_scopes=False, new_class_scope=False):
         """
-        Return a new C{ScopeStack} with an additional empty scope.
+        Return a new ``ScopeStack`` with an additional empty scope.
 
-        @param include_class_scopes:
+        :param include_class_scopes:
           Whether to include previous scopes that are meant for ClassDefs.
-        @param new_class_scope:
+        :param new_class_scope:
           Whether the new scope is for a ClassDef.
-        @rtype:
-          C{ScopeStack}
+        :rtype:
+          ``ScopeStack``
         """
         if include_class_scopes:
             scopes = tuple(self)
@@ -108,7 +108,7 @@ class ScopeStack(tuple):
 
     def clone_top(self):
         """
-        Return a new C{ScopeStack} referencing the same namespaces as C{self},
+        Return a new ``ScopeStack`` referencing the same namespaces as ``self``,
         but cloning the topmost namespace (and aliasing the others).
         """
         scopes = list(self)
@@ -120,8 +120,8 @@ class ScopeStack(tuple):
         """
         Return a 2-tuple of dicts.
 
-        These can be used for functions that take a C{globals} and C{locals}
-        argument, such as C{eval}.
+        These can be used for functions that take a ``globals`` and ``locals``
+        argument, such as ``eval``.
 
         If there is only one entry, then return it twice.
 
@@ -129,8 +129,8 @@ class ScopeStack(tuple):
         the more-global ones.  The most-local stack will alias the dict from
         the existing ScopeStack.
 
-        @rtype:
-          C{tuple} of (C{dict}, C{dict})
+        :rtype:
+          ``tuple`` of (``dict``, ``dict``)
         """
         assert len(self) >= 1
         if len(self) == 1:
@@ -166,11 +166,11 @@ class ScopeStack(tuple):
 
 def symbol_needs_import(fullname, namespaces):
     """
-    Return whether C{fullname} is a symbol that needs to be imported, given
+    Return whether ``fullname`` is a symbol that needs to be imported, given
     the current namespace scopes.
 
     A symbol needs importing if it is not previously imported or otherwise
-    assigned.  C{namespaces} normally includes builtins and globals as well as
+    assigned.  ``namespaces`` normally includes builtins and globals as well as
     symbols imported/assigned locally within the scope.
 
     If the user requested "foo.bar.baz", and we see that "foo.bar" exists
@@ -180,18 +180,18 @@ def symbol_needs_import(fullname, namespaces):
     getattr(foo.bar, "baz"), since that could invoke code that is slow or
     has side effects.
 
-    @type fullname:
-      C{DottedIdentifier}
-    @param fullname:
+    :type fullname:
+      ``DottedIdentifier``
+    :param fullname:
       Fully-qualified symbol name, e.g. "os.path.join".
-    @type namespaces:
-      C{list} of C{dict}
-    @param namespaces:
+    :type namespaces:
+      ``list`` of ``dict``
+    :param namespaces:
       Stack of namespaces to search for existing items.
-    @rtype:
-      C{bool}
-    @return:
-      C{True} if C{fullname} needs import, else C{False}
+    :rtype:
+      ``bool``
+    :return:
+      ``True`` if ``fullname`` needs import, else ``False``
     """
     namespaces = ScopeStack(namespaces)
     fullname = DottedIdentifier(fullname)
@@ -239,7 +239,7 @@ def symbol_needs_import(fullname, namespaces):
                 #     type ModuleType.
                 if var is not sys.modules.get(pname, object()):
                     # The variable is not a module.  (If this came from a
-                    # local assignment then C{var} will just be "None"
+                    # local assignment then ``var`` will just be "None"
                     # here to indicate we know it was assigned but don't
                     # know about its type.)  Thus nothing under it needs
                     # import.
@@ -284,13 +284,14 @@ class _UseChecker(object):
 
 class _MissingImportFinder(object):
     """
-    A helper class to be used only by L{_find_missing_imports_in_ast}.
+    A helper class to be used only by `_find_missing_imports_in_ast`.
 
     This class visits every AST node and collects symbols that require
     importing.  A symbol requires importing if it is not already imported or
     otherwise defined/assigned in this scope.
 
     For attributes like "foo.bar.baz", we need to be more sophisticated:
+
     Suppose the user imports "foo.bar" and then accesses "foo.bar.baz.quux".
     Baz may be already available just by importing foo.bar, or it may require
     further import.  We decide as follows.  If foo.bar is not a module, then
@@ -304,9 +305,9 @@ class _MissingImportFinder(object):
         """
         Construct the AST visitor.
 
-        @type scopestack:
-          L{ScopeStack}
-        @param scopestack:
+        :type scopestack:
+          `ScopeStack`
+        :param scopestack:
           Initial scope stack.
         """
         # Create a stack of namespaces.  The caller should pass in a list that
@@ -347,7 +348,7 @@ class _MissingImportFinder(object):
             self.scopestack = oldscopestack
 
     def scan_for_import_issues(self, codeblock):
-        # See global L{scan_for_import_issues}
+        # See global `scan_for_import_issues`
         codeblock = PythonBlock(codeblock)
         node = codeblock.ast_node
         self._scan_node(node)
@@ -376,7 +377,7 @@ class _MissingImportFinder(object):
                 self.scopestack = self.scopestack.with_new_scope()
                 self._scan_node(block.ast_node)
                 self.scopestack = oldstack
-            # Find literal brace identifiers like "... L{Foo} ...".
+            # Find literal brace identifiers like "... `Foo` ...".
             # TODO: Do this inline: (1) faster; (2) can use proper scope of vars
             # Once we do that, use _check_load() with new args
             # check_missing_imports=False, check_unused_imports=True
@@ -398,8 +399,8 @@ class _MissingImportFinder(object):
         """
         Visit a node.
 
-        @type node:
-          C{ast.AST} or C{list} of C{ast.AST}
+        :type node:
+          ``ast.AST`` or ``list`` of ``ast.AST``
         """
         # Modification of ast.NodeVisitor.visit().  Support list inputs.
         logger.debug("_MissingImportFinder.visit(%r)", node)
@@ -419,7 +420,7 @@ class _MissingImportFinder(object):
     def generic_visit(self, node):
         """
         Generic visitor that visits all of the node's field values, in the
-        order declared by C{node._fields}.
+        order declared by ``node._fields``.
 
         Called if no explicit visitor function exists for a node.
         """
@@ -756,7 +757,7 @@ class _MissingImportFinder(object):
                 # 'del foo.bar.baz', 'del foo().bar', etc
                 # We ignore the 'del ...bar' part and just visit the
                 # left-hand-side of the delattr.  We need to do this explicitly
-                # instead of relying on a generic_visit on C{node} itself.
+                # instead of relying on a generic_visit on ``node`` itself.
                 # Reason: We want visit_Attribute to process a getattr for
                 # 'foo.bar'.
                 self.visit(target.value)
@@ -842,15 +843,16 @@ def scan_for_import_issues(codeblock, find_unused_imports=True, parse_docstrings
       >>> unused
       [(1, Import('from aa import bb as cc'))]
 
-    @type codeblock:
-      C{PythonBlock}
-    @type namespaces:
-      C{dict} or C{list} of C{dict}
-    @param parse_docstrings:
+    :type codeblock:
+      ``PythonBlock``
+    :type namespaces:
+      ``dict`` or ``list`` of ``dict``
+    :param parse_docstrings:
       Whether to parse docstrings.
       Compare the following examples.  When parse_docstrings=True, 'bar' is
       not considered unused because there is a string that references it in
-      braces:
+      braces::
+
         >>> scan_for_import_issues("import foo as bar, baz\\n'{bar}'\\n")
         ([], [(1, Import('import baz')), (1, Import('import foo as bar'))])
         >>> scan_for_import_issues("import foo as bar, baz\\n'{bar}'\\n", parse_docstrings=True)
@@ -869,18 +871,18 @@ def scan_for_import_issues(codeblock, find_unused_imports=True, parse_docstrings
 def _find_missing_imports_in_ast(node, namespaces):
     """
     Find missing imports in an AST node.
-    Helper function to L{find_missing_imports}.
+    Helper function to `find_missing_imports`.
 
       >>> node = ast.parse("import numpy; numpy.arange(x) + arange(x)")
       >>> _find_missing_imports_in_ast(node, [{}])
       [DottedIdentifier('arange'), DottedIdentifier('x')]
 
-    @type node:
-      C{ast.AST}
-    @type namespaces:
-      C{dict} or C{list} of C{dict}
-    @rtype:
-      C{list} of C{DottedIdentifier}
+    :type node:
+      ``ast.AST``
+    :type namespaces:
+      ``dict`` or ``list`` of ``dict``
+    :rtype:
+      ``list`` of ``DottedIdentifier``
     """
     if not isinstance(node, ast.AST):
         raise TypeError
@@ -899,7 +901,7 @@ def _find_missing_imports_in_ast(node, namespaces):
 def _find_missing_imports_in_code(co, namespaces):
     """
     Find missing imports in a code object.
-    Helper function to L{find_missing_imports}.
+    Helper function to `find_missing_imports`.
 
       >>> f = lambda: foo.bar(x) + baz(y)
       >>> [str(m) for m in _find_missing_imports_in_code(f.__code__, [{}])]
@@ -909,12 +911,12 @@ def _find_missing_imports_in_code(co, namespaces):
       >>> _find_missing_imports_in_code(f.__code__, [{}])
       [DottedIdentifier('y')]
 
-    @type co:
-      C{types.CodeType}
-    @type namespaces:
-      C{dict} or C{list} of C{dict}
-    @rtype:
-      C{list} of C{str}
+    :type co:
+      ``types.CodeType``
+    :type namespaces:
+      ``dict`` or ``list`` of ``dict``
+    :rtype:
+      ``list`` of ``str``
     """
     loads_without_stores = set()
     _find_loads_without_stores_in_code(co, loads_without_stores)
@@ -928,18 +930,18 @@ def _find_missing_imports_in_code(co, namespaces):
 def _find_loads_without_stores_in_code(co, loads_without_stores):
     """
     Find global LOADs without corresponding STOREs, by disassembling code.
-    Recursive helper for L{_find_missing_imports_in_code}.
+    Recursive helper for `_find_missing_imports_in_code`.
 
-    @type co:
-      C{types.CodeType}
-    @param co:
-      Code object, e.g. C{function.__code__}
-    @type loads_without_stores:
-      C{set}
-    @param loads_without_stores:
+    :type co:
+      ``types.CodeType``
+    :param co:
+      Code object, e.g. ``function.__code__``
+    :type loads_without_stores:
+      ``set``
+    :param loads_without_stores:
       Mutable set to which we add loads without stores.
-    @return:
-      C{None}
+    :return:
+      ``None``
     """
     if not isinstance(co, types.CodeType):
         raise TypeError(
@@ -955,11 +957,11 @@ def _find_loads_without_stores_in_code(co, loads_without_stores):
     STORE_GLOBAL = opmap['STORE_GLOBAL']
     STORE_NAME   = opmap['STORE_NAME']
     # Keep track of the partial name so far that started with a LOAD_GLOBAL.
-    # If C{pending} is not None, then it is a list representing the name
+    # If ``pending`` is not None, then it is a list representing the name
     # components we've seen so far.
     pending = None
     # Disassemble the code.  Look for LOADs and STOREs.  This code is based on
-    # C{dis.disassemble}.
+    # ``dis.disassemble``.
     #
     # Scenarios:
     #
@@ -1144,7 +1146,7 @@ def _find_loads_without_stores_in_code(co, loads_without_stores):
     loads_without_stores.update( loads_before_label_without_stores ) # case 1
     loads_without_stores.update( loads_after_label - stores )        # case 2
 
-    # The C{pending} variable should have been reset at this point, because a
+    # The ``pending`` variable should have been reset at this point, because a
     # function should always end with a RETURN_VALUE opcode and therefore not
     # end in a LOAD_ATTR.
     assert pending is None
@@ -1166,7 +1168,8 @@ def _find_earliest_backjump_label(bytecode):
 
     These normally represent loops.
 
-    For example, given the source code:
+    For example, given the source code::
+
       >>> def f():
       ...     if foo1():
       ...         foo2()
@@ -1177,6 +1180,7 @@ def _find_earliest_backjump_label(bytecode):
       ...         foo6()
 
     In python 2.6, the disassembled bytecode is::
+
       >> import dis
       >> dis.dis(f)
         2           0 LOAD_GLOBAL              0 (foo1)
@@ -1215,6 +1219,7 @@ def _find_earliest_backjump_label(bytecode):
 
     The earliest target of a backward jump would be the 'while' loop at L7, at
     bytecode offset 38::
+
       >> _find_earliest_backjump_label(f.__code__.co_code)
       38
 
@@ -1225,13 +1230,13 @@ def _find_earliest_backjump_label(bytecode):
     If there are no backward jumps, return an offset that points after the end
     of the bytecode.
 
-    @type bytecode:
-      C{bytes}
-    @param bytecode:
-      Compiled bytecode, e.g. C{function.__code__.co_code}.
-    @rtype:
-      C{int}
-    @return:
+    :type bytecode:
+      ``bytes``
+    :param bytecode:
+      Compiled bytecode, e.g. ``function.__code__.co_code``.
+    :rtype:
+      ``int``
+    :return:
       The earliest target of a backward jump, as an offset into the bytecode.
     """
     # Code based on dis.findlabels().
@@ -1274,27 +1279,32 @@ def find_missing_imports(arg, namespaces):
     in the same lexical scope.
 
     For example, if we use an empty list of namespaces, then "os.path.join" is
-    a symbol that requires import:
+    a symbol that requires import::
+
       >>> [str(m) for m in find_missing_imports("os.path.join", namespaces=[{}])]
       ['os.path.join']
 
     But if the global namespace already has the "os" module imported, then we
-    know that C{os} has a "path" attribute, which has a "join" attribute, so
-    nothing needs import:
+    know that ``os`` has a "path" attribute, which has a "join" attribute, so
+    nothing needs import::
+
       >>> import os
       >>> find_missing_imports("os.path.join", namespaces=[{"os":os}])
       []
 
-    Builtins are always included:
+    Builtins are always included::
+
       >>> [str(m) for m in find_missing_imports("os, sys, eval", [{"os": os}])]
       ['sys']
 
-    All symbols that are not defined are included:
+    All symbols that are not defined are included::
+
       >>> [str(m) for m in find_missing_imports("numpy.arange(x) + arange(y)", [{"y": 3}])]
       ['arange', 'numpy.arange', 'x']
 
     If something is imported/assigned/etc within the scope, then we assume it
-    doesn't require importing:
+    doesn't require importing::
+
       >>> [str(m) for m in find_missing_imports("import numpy; numpy.arange(x) + arange(x)", [{}])]
       ['arange', 'x']
 
@@ -1311,16 +1321,19 @@ def find_missing_imports(arg, namespaces):
       ['a.b.x', 'a.b.z']
 
     find_missing_imports() parses the AST, so it understands scoping.  In the
-    following example, C{x} is never undefined:
+    following example, ``x`` is never undefined::
+
       >>> find_missing_imports("(lambda x: x*x)(7)", [{}])
       []
 
-    but this example, C{x} is undefined at global scope:
+    but this example, ``x`` is undefined at global scope::
+
       >>> [str(m) for m in find_missing_imports("(lambda x: x*x)(7) + x", [{}])]
       ['x']
 
     The (unintuitive) rules for generator expressions and list comprehensions
-    in Python 2 are handled correctly:
+    in Python 2 are handled correctly::
+
       >>> # Python 3
       >>> [str(m) for m in find_missing_imports("[x+y+z for x,y in [(1,2)]], y", [{}])] # doctest: +SKIP
       ['y', 'z']
@@ -1332,23 +1345,23 @@ def find_missing_imports(arg, namespaces):
       >>> [str(m) for m in find_missing_imports("(x+y+z for x,y in [(1,2)]), y", [{}])]
       ['y', 'z']
 
-    Only fully-qualified names starting at top-level are included:
+    Only fully-qualified names starting at top-level are included::
 
       >>> [str(m) for m in find_missing_imports("( ( a . b ) . x ) . y + ( c + d ) . x . y", [{}])]
       ['a.b.x.y', 'c', 'd']
 
-    @type arg:
-      C{str}, C{ast.AST}, L{PythonBlock}, C{callable}, or C{types.CodeType}
-    @param arg:
+    :type arg:
+      ``str``, ``ast.AST``, `PythonBlock`, ``callable``, or ``types.CodeType``
+    :param arg:
       Python code, either as source text, a parsed AST, or compiled code; can
       be as simple as a single qualified name, or as complex as an entire
       module text.
-    @type namespaces:
-      C{dict} or C{list} of C{dict}
-    @param namespaces:
+    :type namespaces:
+      ``dict`` or ``list`` of ``dict``
+    :param namespaces:
       Stack of namespaces of symbols that exist per scope.
-    @rtype:
-      C{list} of C{DottedIdentifier}
+    :rtype:
+      ``list`` of ``DottedIdentifier``
     """
     namespaces = ScopeStack(namespaces)
     if isinstance(arg, (DottedIdentifier, six.string_types)):
@@ -1398,14 +1411,15 @@ def get_known_import(fullname, db=None):
     Get the deepest known import.
 
     For example, suppose:
+
       - The user accessed "foo.bar.baz",
       - We know imports for "foo", "foo.bar", and "foo.bar.quux".
 
     Then we return "import foo.bar".
 
-    @type fullname:
-      L{DottedIdentifier}
-    @param fullname:
+    :type fullname:
+      `DottedIdentifier`
+    :param fullname:
       Fully-qualified name, such as "scipy.interpolate"
     """
     # Get the import database.
@@ -1444,22 +1458,22 @@ def clear_failed_imports_cache():
 def _try_import(imp, namespace):
     """
     Try to execute an import.  Import the result into the namespace
-    C{namespace}.
+    ``namespace``.
 
     Print to stdout what we're about to do.
 
-    Only import into C{namespace} if we won't clobber an existing definition.
+    Only import into ``namespace`` if we won't clobber an existing definition.
 
-    @type imp:
-      C{Import} or C{str}
-    @param imp:
+    :type imp:
+      ``Import`` or ``str``
+    :param imp:
       The import to execute, e.g. "from numpy import arange"
-    @type namespace:
-      C{dict}
-    @param namespace:
+    :type namespace:
+      ``dict``
+    :param namespace:
       Namespace to import into.
-    @return:
-      C{True} on success, C{False} on failure
+    :return:
+      ``True`` on success, ``False`` on failure
     """
     # TODO: generalize "imp" to any python statement whose toplevel is a
     # single Store (most importantly import and assignment, but could also
@@ -1473,9 +1487,9 @@ def _try_import(imp, namespace):
     name0 = impas.split(".", 1)[0]
     stmt = str(imp)
     logger.info(stmt)
-    # Do the import in a temporary namespace, then copy it to C{namespace}
+    # Do the import in a temporary namespace, then copy it to ``namespace``
     # manually.  We do this instead of just importing directly into
-    # C{namespace} for the following reason: Suppose the user wants "foo.bar",
+    # ``namespace`` for the following reason: Suppose the user wants "foo.bar",
     # but "foo" already exists in the global namespace.  In order to import
     # "foo.bar" we need to import its parent module "foo".  We only want to do
     # the "foo.bar" import if what we import as "foo" is the same as the
@@ -1512,34 +1526,34 @@ def auto_import_symbol(fullname, namespaces, db=None, autoimported=None, post_im
     """
     Try to auto-import a single name.
 
-    @type fullname:
-      C{str}
-    @param fullname:
+    :type fullname:
+      ``str``
+    :param fullname:
       Fully-qualified module name, e.g. "sqlalchemy.orm".
-    @type namespaces:
-      C{list} of C{dict}, e.g. [globals()].
-    @param namespaces:
+    :type namespaces:
+      ``list`` of ``dict``, e.g. [globals()].
+    :param namespaces:
       Namespaces to check.  Namespace[-1] is the namespace to import into.
-    @type db:
-      L{ImportDB}
-    @param db:
+    :type db:
+      `ImportDB`
+    :param db:
       Import database to use.
-    @param autoimported:
-      If not C{None}, then a dictionary of identifiers already attempted.
-      C{auto_import} will not attempt to auto-import symbols already in this
+    :param autoimported:
+      If not ``None``, then a dictionary of identifiers already attempted.
+      ``auto_import`` will not attempt to auto-import symbols already in this
       dictionary, and will add attempted symbols to this dictionary, with
-      value C{True} if the autoimport succeeded, or C{False} if the autoimport
+      value ``True`` if the autoimport succeeded, or ``False`` if the autoimport
       did not succeed.
-    @rtype:
-      C{bool}
-    @param post_import_hook:
+    :rtype:
+      ``bool``
+    :param post_import_hook:
       A callable that is invoked if an import was successfully made.
-      It is invoked with the L{Import} object representing the successful import
-    @type post_import_hook:
-      C{callable}
-    @return:
-      C{True} if the symbol was already in the namespace, or the auto-import
-      succeeded; C{False} if the auto-import failed.
+      It is invoked with the `Import` object representing the successful import
+    :type post_import_hook:
+      ``callable``
+    :return:
+      ``True`` if the symbol was already in the namespace, or the auto-import
+      succeeded; ``False`` if the auto-import failed.
     """
     namespaces = ScopeStack(namespaces)
     if not symbol_needs_import(fullname, namespaces):
@@ -1626,41 +1640,41 @@ def auto_import_symbol(fullname, namespaces, db=None, autoimported=None, post_im
 
 def auto_import(arg, namespaces, db=None, autoimported=None, post_import_hook=None):
     """
-    Parse C{arg} for symbols that need to be imported and automatically import
+    Parse ``arg`` for symbols that need to be imported and automatically import
     them.
 
-    @type arg:
-      C{str}, C{ast.AST}, L{PythonBlock}, C{callable}, or C{types.CodeType}
-    @param arg:
+    :type arg:
+      ``str``, ``ast.AST``, `PythonBlock`, ``callable``, or ``types.CodeType``
+    :param arg:
       Python code, either as source text, a parsed AST, or compiled code; can
       be as simple as a single qualified name, or as complex as an entire
       module text.
-    @type namespaces:
-      C{dict} or C{list} of C{dict}
-    @param namespaces:
+    :type namespaces:
+      ``dict`` or ``list`` of ``dict``
+    :param namespaces:
       Namespaces to check.  Namespace[-1] is the namespace to import into.
-    @type db:
-      L{ImportDB}
-    @param db:
+    :type db:
+      `ImportDB`
+    :param db:
       Import database to use.
-    @type autoimported:
-      C{dict}
-    @param autoimported:
-      If not C{None}, then a dictionary of identifiers already attempted.
-      C{auto_import} will not attempt to auto-import symbols already in this
+    :type autoimported:
+      ``dict``
+    :param autoimported:
+      If not ``None``, then a dictionary of identifiers already attempted.
+      ``auto_import`` will not attempt to auto-import symbols already in this
       dictionary, and will add attempted symbols to this dictionary, with
-      value C{True} if the autoimport succeeded, or C{False} if the autoimport
+      value ``True`` if the autoimport succeeded, or ``False`` if the autoimport
       did not succeed.
-    @rtype:
-      C{bool}
-    @param post_import_hook:
+    :rtype:
+      ``bool``
+    :param post_import_hook:
       A callable invoked on each successful import. This is passed to
-      L{auto_import_symbol}
-    @type post_import_hook:
-      C{callable}
-    @return:
-      C{True} if all symbols are already in the namespace or successfully
-      auto-imported; C{False} if any auto-imports failed.
+      `auto_import_symbol`
+    :type post_import_hook:
+      ``callable``
+    :return:
+      ``True`` if all symbols are already in the namespace or successfully
+      auto-imported; ``False`` if any auto-imports failed.
     """
     namespaces = ScopeStack(namespaces)
     if isinstance(arg, PythonBlock):
@@ -1690,13 +1704,15 @@ def auto_eval(arg, filename=None, mode=None,
     """
     Evaluate/execute the given code, automatically importing as needed.
 
-    C{auto_eval} will default the compilation C{mode} to "eval" if possible:
+    ``auto_eval`` will default the compilation ``mode`` to "eval" if possible::
+
       >>> auto_eval("b64decode('aGVsbG8=')") + b"!"
       [PYFLYBY] from base64 import b64decode
       b'hello!'
 
-    C{auto_eval} will default the compilation C{mode} to "exec" if the input
-    is not a single expression:
+    ``auto_eval`` will default the compilation ``mode`` to "exec" if the input
+    is not a single expression::
+
       >>> auto_eval("if True: print(b64decode('aGVsbG8=').decode('utf-8'))")
       [PYFLYBY] from base64 import b64decode
       hello
@@ -1704,45 +1720,45 @@ def auto_eval(arg, filename=None, mode=None,
     This is roughly equivalent to "auto_import(arg); eval(arg)", but handles
     details better and more efficiently.
 
-    @type arg:
-      C{str}, C{ast.AST}, C{code}, L{Filename}, L{FileText}, L{PythonBlock}
-    @param arg:
+    :type arg:
+      ``str``, ``ast.AST``, ``code``, `Filename`, `FileText`, `PythonBlock`
+    :param arg:
       Code to evaluate.
-    @type filename:
-      C{str}
-    @param filename:
-      Filename for compilation error messages.  If C{None}, defaults to
-      C{arg.filename} if relevant, else C{"<stdin>"}.
-    @type mode:
-      C{str}
-    @param mode:
-      Compilation mode: C{None}, "exec", "single", or "eval".  "exec",
-      "single", and "eval" work as the built-in C{compile} function do.
-      If C{None}, then default to "eval" if the input is a string with a
+    :type filename:
+      ``str``
+    :param filename:
+      Filename for compilation error messages.  If ``None``, defaults to
+      ``arg.filename`` if relevant, else ``"<stdin>"``.
+    :type mode:
+      ``str``
+    :param mode:
+      Compilation mode: ``None``, "exec", "single", or "eval".  "exec",
+      "single", and "eval" work as the built-in ``compile`` function do.
+      If ``None``, then default to "eval" if the input is a string with a
       single expression, else "exec".
-    @type flags:
-      C{CompilerFlags} or convertible (C{int}, C{list} of C{str}, etc.)
-    @param flags:
+    :type flags:
+      ``CompilerFlags`` or convertible (``int``, ``list`` of ``str``, etc.)
+    :param flags:
       Compilation feature flags, e.g. ["division", "with_statement"].  If
-      C{None}, defaults to no flags.  Does not inherit flags from parent
+      ``None``, defaults to no flags.  Does not inherit flags from parent
       scope.
-    @type auto_flags:
-      C{bool}
-    @param auto_flags:
-      Whether to try other flags if C{flags} causes SyntaxError.
-    @type globals:
-      C{dict}
-    @param globals:
-      Globals for evaluation.  If C{None}, use an empty dictionary.
-    @type locals:
-      C{dict}
-    @param locals:
-      Locals for evaluation.  If C{None}, use C{globals}.
-    @type db:
-      L{ImportDB}
-    @param db:
+    :type auto_flags:
+      ``bool``
+    :param auto_flags:
+      Whether to try other flags if ``flags`` causes SyntaxError.
+    :type globals:
+      ``dict``
+    :param globals:
+      Globals for evaluation.  If ``None``, use an empty dictionary.
+    :type locals:
+      ``dict``
+    :param locals:
+      Locals for evaluation.  If ``None``, use ``globals``.
+    :type db:
+      `ImportDB`
+    :param db:
       Import database to use.
-    @return:
+    :return:
       Result of evaluation (for mode="eval")
     """
     flags = CompilerFlags(flags)
@@ -1778,7 +1794,7 @@ def auto_eval(arg, filename=None, mode=None,
         # Infer mode from ast object.
         mode = infer_compile_mode(arg)
         # Compile ast node => code object.  This step is necessary because
-        # eval() doesn't work on AST objects.  We don't need to pass C{flags}
+        # eval() doesn't work on AST objects.  We don't need to pass ``flags``
         # to compile() because flags are irrelevant when we already have an
         # AST node.
         code = compile(arg, str(filename or "<unknown>"), mode)
@@ -1800,7 +1816,7 @@ class LoadSymbolError(Exception):
 def load_symbol(fullname, namespaces, autoimport=False, db=None,
                 autoimported=None):
     """
-    Load the symbol C{fullname}.
+    Load the symbol ``fullname``.
 
       >>> import os
       >>> load_symbol("os.path.join.__name__", {"os": os})
@@ -1808,38 +1824,40 @@ def load_symbol(fullname, namespaces, autoimport=False, db=None,
 
       >>> load_symbol("os.path.join.asdf", {"os": os})
       Traceback (most recent call last):
+
         ...
       pyflyby._autoimp.LoadSymbolError: os.path.join.asdf: AttributeError: 'function' object has no attribute 'asdf'
 
       >>> load_symbol("os.path.join", {})
       Traceback (most recent call last):
+
         ...
       pyflyby._autoimp.LoadSymbolError: os.path.join: NameError: os
 
-    @type fullname:
-      C{str}
-    @param fullname:
+    :type fullname:
+      ``str``
+    :param fullname:
       Fully-qualified symbol name, e.g. "os.path.join".
-    @type namespaces:
-      C{dict} or C{list} of C{dict}
-    @param namespaces:
+    :type namespaces:
+      ``dict`` or ``list`` of ``dict``
+    :param namespaces:
       Namespaces to check.
-    @param autoimport:
-      If C{False} (default), the symbol must already be imported.
-      If C{True}, then auto-import the symbol first.
-    @type db:
-      L{ImportDB}
-    @param db:
-      Import database to use when C{autoimport=True}.
-    @param autoimported:
-      If not C{None}, then a dictionary of identifiers already attempted.
-      C{auto_import} will not attempt to auto-import symbols already in this
+    :param autoimport:
+      If ``False`` (default), the symbol must already be imported.
+      If ``True``, then auto-import the symbol first.
+    :type db:
+      `ImportDB`
+    :param db:
+      Import database to use when ``autoimport=True``.
+    :param autoimported:
+      If not ``None``, then a dictionary of identifiers already attempted.
+      ``auto_import`` will not attempt to auto-import symbols already in this
       dictionary, and will add attempted symbols to this dictionary, with
-      value C{True} if the autoimport succeeded, or C{False} if the autoimport
+      value ``True`` if the autoimport succeeded, or ``False`` if the autoimport
       did not succeed.
-    @return:
+    :return:
       Object.
-    @raise LoadSymbolError:
+    :raise LoadSymbolError:
       Object was not found or there was another exception.
     """
     namespaces = ScopeStack(namespaces)

--- a/lib/python/pyflyby/_cmdline.py
+++ b/lib/python/pyflyby/_cmdline.py
@@ -262,8 +262,8 @@ def filename_args(args, on_error=_default_on_error):
     """
     Return list of filenames given command-line arguments.
 
-    @rtype:
-      C{list} of L{Filename}
+    :rtype:
+      ``list`` of `Filename`
     """
     if args:
         return expand_py_files_from_args(args, on_error)

--- a/lib/python/pyflyby/_dbg.py
+++ b/lib/python/pyflyby/_dbg.py
@@ -99,9 +99,9 @@ def _StdioCtx(tty="/dev/tty"):
     sys.{stdin,stdout,stderr} to fd.  This allows us to use the debugger even
     if stdio is otherwise redirected.
 
-    @type tty:
-      C{int} or C{str}
-    @param tty:
+    :type tty:
+      ``int`` or ``str``
+    :param tty:
       Tty to use.  Either a file descriptor or a name of a tty.
     '''
     from ._interactive import UpdateIPythonStdioCtx
@@ -163,7 +163,7 @@ def _StdioCtx(tty="/dev/tty"):
 @contextmanager
 def _ExceptHookCtx():
     '''
-    Context manager that restores C{sys.excepthook} upon exit.
+    Context manager that restores ``sys.excepthook`` upon exit.
     '''
     saved_excepthook = sys.excepthook
     try:
@@ -176,7 +176,7 @@ def _ExceptHookCtx():
 @contextmanager
 def _DisplayHookCtx():
     '''
-    Context manager that resets C{sys.displayhook} to the default value upon
+    Context manager that resets ``sys.displayhook`` to the default value upon
     entry, and restores the pre-context value upon exit.
     '''
     saved_displayhook = sys.displayhook
@@ -193,7 +193,7 @@ def print_traceback(*exc_info):
 
     Output goes to /dev/tty.
 
-    @param exc_info:
+    :param exc_info:
       3 arguments as returned by sys.exc_info().
     """
     from pyflyby._interactive import print_verbose_tb
@@ -209,7 +209,7 @@ def _DebuggerCtx(tty="/dev/tty"):
     A context manager that sets up the environment (stdio, sys hooks) for a
     debugger, initializes IPython if necessary, and creates a debugger instance.
 
-    @return:
+    :return:
       Context manager that yields a Pdb instance.
     """
     from pyflyby._interactive import new_IPdb_instance
@@ -225,8 +225,8 @@ def _get_caller_frame():
     '''
     Get the closest frame from outside this module.
 
-    @rtype:
-      C{FrameType}
+    :rtype:
+      ``FrameType``
     '''
     this_filename = _get_caller_frame.__code__.co_filename
     f = sys._getframe()
@@ -277,9 +277,9 @@ def _debug_code(arg, globals=None, locals=None, auto_import=True, tty="/dev/tty"
     """
     Run code under the debugger.
 
-    @type arg:
-      C{str}, C{Callable}, C{CodeType}, C{PythonStatement}, C{PythonBlock},
-      C{FileText}
+    :type arg:
+      ``str``, ``Callable``, ``CodeType``, ``PythonStatement``, ``PythonBlock``,
+      ``FileText``
     """
     if globals is None or locals is None:
         caller_frame = _get_caller_frame()
@@ -322,7 +322,7 @@ def debugger(*args, **kwargs):
     '''
     Entry point for debugging.
 
-    C{debugger()} can be used in the following ways:
+    ``debugger()`` can be used in the following ways::
 
     1. Breakpoint mode, entering debugger in executing code::
          >> def foo():
@@ -351,7 +351,7 @@ def debugger(*args, **kwargs):
          >> debugger(foo)
          >> debugger(lambda: foo(6))
 
-    4. Debug an exception:
+    4. Debug an exception::
 
          >> try:
          ..     ...
@@ -366,10 +366,10 @@ def debugger(*args, **kwargs):
     with no stepping allowed.  The process will continue running after this
     debug session's "continue".
 
-    C{debugger()} is suitable to be called interactively, from scripts, in
+    ``debugger()`` is suitable to be called interactively, from scripts, in
     sys.excepthook, and in signal handlers.
 
-    @param args:
+    :param args:
       What to debug:
         - If a string or callable, then run it under the debugger.
         - If a frame, then debug the frame.
@@ -380,23 +380,23 @@ def debugger(*args, **kwargs):
           is attaching a debugger.
         - If nothing specified, then enter the debugger at the statement
           following the call to debug().
-    @kwarg tty:
-      Tty to connect to.  If C{None} (default): if /dev/tty is usable, then
+    :kwarg tty:
+      Tty to connect to.  If ``None`` (default): if /dev/tty is usable, then
       use it; else call wait_for_debugger_to_attach() instead (unless
       wait_for_attach==False).
-    @kwarg on_continue:
+    :kwarg on_continue:
       Function to call upon exiting the debugger and continuing with regular
       execution.
-    @kwarg wait_for_attach:
+    :kwarg wait_for_attach:
       Whether to wait for a remote terminal to attach (with 'py -d PID').
-      If C{True}, then always wait for a debugger to attach.
-      If C{False}, then never wait for a debugger to attach; debug in the
+      If ``True``, then always wait for a debugger to attach.
+      If ``False``, then never wait for a debugger to attach; debug in the
       current terminal.
-      If unset, then defaults to true only when C{tty} is unspecified and
+      If unset, then defaults to true only when ``tty`` is unspecified and
       /dev/tty is not usable.
-    @kwarg background:
-      If C{False}, then pause execution to debug.
-      If C{True}, then fork a process and wait for a debugger to attach in the
+    :kwarg background:
+      If ``False``, then pause execution to debug.
+      If ``True``, then fork a process and wait for a debugger to attach in the
       forked child.
     '''
     from ._parse import PythonStatement, PythonBlock, FileText
@@ -550,16 +550,16 @@ def wait_for_debugger_to_attach(arg, mailto=None, background=False, timeout=8640
     """
     Send email to user and wait for debugger to attach.
 
-    @param arg:
+    :param arg:
       What to debug.  Should be a sys.exc_info() result or a sys._getframe()
       result.
-    @param mailto:
+    :param mailto:
       Recipient to email.  Defaults to $USER or current user.
-    @param background:
+    :param background:
       If True, fork a child process.  The parent process continues immediately
       without waiting.  The child process waits for a debugger to attach, and
       exits when the debugging session completes.
-    @param timeout:
+    :param timeout:
       Maximum number of seconds to wait for user to attach debugger.
     """
     import traceback
@@ -772,7 +772,7 @@ def enable_signal_handler_debugger(enable=True):
 
 def enable_exception_handler_debugger():
     '''
-    Enable C{sys.excepthook = debugger} so that we automatically enter
+    Enable ``sys.excepthook = debugger`` so that we automatically enter
     the debugger upon uncaught exceptions.
     '''
     sys.excepthook = debugger
@@ -794,12 +794,12 @@ def enable_sigterm_handler(on_existing_handler='raise'):
     Install a handler for SIGTERM that causes Python to print a stack trace
     before exiting.
 
-    @param on_existing_handler:
+    :param on_existing_handler:
       What to do when a SIGTERM handler was already registered.
-        - If C{"raise"}, then keep the existing handler and raise an exception.
-        - If C{"keep_existing"}, then silently keep the existing handler.
-        - If C{"warn_and_override"}, then override the existing handler and log a warning.
-        - If C{"silently_override"}, then silently override the existing handler.
+        - If ``"raise"``, then keep the existing handler and raise an exception.
+        - If ``"keep_existing"``, then silently keep the existing handler.
+        - If ``"warn_and_override"``, then override the existing handler and log a warning.
+        - If ``"silently_override"``, then silently override the existing handler.
     """
     old_handler = signal.signal(signal.SIGTERM, _sigterm_handler)
     if old_handler == signal.SIG_DFL or old_handler == _sigterm_handler:
@@ -861,10 +861,10 @@ def get_executable(pid):
     """
     Get the full path for the target process.
 
-    @type pid:
-      C{int}
-    @rtype:
-      L{Filename}
+    :type pid:
+      ``int``
+    :rtype:
+      `Filename`
     """
     uname = os.uname()[0]
     if uname == 'Linux':
@@ -909,8 +909,8 @@ def _dev_null_w():
     Return a file object opened for writing to /dev/null.
     Memoized.
 
-    @rtype:
-      C{file}
+    :rtype:
+      ``file``
     """
     global _memoized_dev_null_w
     if _memoized_dev_null_w is None:
@@ -920,19 +920,19 @@ def _dev_null_w():
 
 def inject(pid, statements, wait=True, show_gdb_output=False):
     """
-    Execute C{statements} in a running Python process.
+    Execute ``statements`` in a running Python process.
 
-    @type pid:
-      C{int}
-    @param pid:
+    :type pid:
+      ``int``
+    :param pid:
       Id of target process
-    @type statements:
+    :type statements:
       Iterable of strings
-    @param statements:
+    :param statements:
       Python statements to execute.
-    @return:
-      Then process ID of the gdb process if C{wait} is False; C{None} if
-      C{wait} is True.
+    :return:
+      Then process ID of the gdb process if ``wait`` is False; ``None`` if
+      ``wait`` is True.
     """
     import subprocess
     os.kill(pid, 0) # raises OSError "No such process" unless pid exists
@@ -999,12 +999,12 @@ class Pty(object):
 
 def process_exists(pid):
     """
-    Return whether C{pid} exists.
+    Return whether ``pid`` exists.
 
-    @type pid:
-      C{int}
-    @rtype:
-      C{bool}
+    :type pid:
+      ``int``
+    :rtype:
+      ``bool``
     """
     try:
         os.kill(pid, 0)
@@ -1017,11 +1017,11 @@ def process_exists(pid):
 
 def kill_process(pid, kill_signals):
     """
-    Kill process C{pid} using various signals.
+    Kill process ``pid`` using various signals.
 
-    @param kill_signals:
+    :param kill_signals:
       Sequence of (signal, delay) tuples.  Each signal is tried in sequence,
-      waiting up to C{delay} seconds before trying the next signal.
+      waiting up to ``delay`` seconds before trying the next signal.
     """
     for sig, delay in kill_signals:
         start_time = time.time()
@@ -1042,7 +1042,7 @@ def attach_debugger(pid):
     """
     Attach command-line debugger to a running process.
 
-    @param pid:
+    :param pid:
       Process id of target process.
     """
     import pyflyby
@@ -1107,14 +1107,14 @@ def remote_print_stack(pid, output=1):
     This currently only handles the main thread.
     TODO: handle multiple threads.
 
-    @param pid:
+    :param pid:
       PID of target process.
-    @type output:
-      C{int}, C{file}, or C{str}
-    @param output:
+    :type output:
+      ``int``, ``file``, or ``str``
+    :param output:
       Output file descriptor.
     """
-    # Interpret C{output} argument as a file-like object, file descriptor, or
+    # Interpret ``output`` argument as a file-like object, file descriptor, or
     # filename.
     if hasattr(output, 'write'): # file-like object
         output_fh = output
@@ -1152,7 +1152,7 @@ def remote_print_stack(pid, output=1):
     # simply check whether we ourselves can open the file.  Typically output
     # will be fd 1 and we will have access to write to it.  However, if we're
     # sudoed, we won't be able to re-open it via the proc symlink, even though
-    # we already currently have it open.  Another case is C{output} is a
+    # we already currently have it open.  Another case is ``output`` is a
     # file-like object that isn't a real file, e.g. a StringO.  In each case
     # we we don't have a usable filename for the remote process yet.  To
     # address these situations, we create a temporary file for the remote

--- a/lib/python/pyflyby/_docxref.py
+++ b/lib/python/pyflyby/_docxref.py
@@ -50,11 +50,11 @@ ASSUME_MODULES_OK = set(['numpy'])
 @memoize
 def map_strings_to_line_numbers(module):
     """
-    Walk C{module.ast}, looking at all string literals.  Return a map from
+    Walk ``module.ast``, looking at all string literals.  Return a map from
     string literals to line numbers (1-index).
 
-    @rtype:
-      C{dict} from C{str} to (C{int}, C{str})
+    :rtype:
+      ``dict`` from ``str`` to (``int``, ``str``)
     """
     d = {}
     for field in module.block.string_literals():
@@ -69,10 +69,10 @@ def map_strings_to_line_numbers(module):
 
 def get_string_linenos(module, searchstring, within_string):
     """
-    Return the line numbers (1-indexed) within C{filename} that contain
-    C{searchstring}.  Only consider string literals (i.e. not comments).
-    First look for exact matches of C{within_string} (modulo indenting) and
-    then search within that.  Only if the C{within_string} is not found,
+    Return the line numbers (1-indexed) within ``filename`` that contain
+    ``searchstring``.  Only consider string literals (i.e. not comments).
+    First look for exact matches of ``within_string`` (modulo indenting) and
+    then search within that.  Only if the ``within_string`` is not found,
     search the entire file.
 
     [If there's a comment on the same line as a string that also contains the
@@ -144,10 +144,10 @@ class ExpandedDocIndex(object):
 
     def add_module(self, module):
         """
-        Adds C{module} and recreates the DocIndex with the updated set of
+        Adds ``module`` and recreates the DocIndex with the updated set of
         modules.
 
-        @return:
+        :return:
           Whether anything was added.
         """
         module = ModuleHandle(module)
@@ -287,7 +287,7 @@ class XrefScanner(object):
 
     def check_xref(self, identifier, container):
         """
-        Check that C{identifier} cross-references a proper symbol.
+        Check that ``identifier`` cross-references a proper symbol.
 
         Look in modules that we weren't explicitly asked to look in, if
         needed.
@@ -326,7 +326,7 @@ class XrefScanner(object):
         if check_defining_module(container):
             return True
         # If the user has imported foo.bar.baz as baz and now uses
-        # C{baz.quux}, we need to add the module foo.bar.baz.
+        # ``baz.quux``, we need to add the module foo.bar.baz.
         for prefix in reversed(list(prefixes(
                     DottedIdentifier(remove_epydoc_sym_suffix(identifier))))):
             if check_defining_module(
@@ -373,10 +373,10 @@ def find_bad_doc_cross_references(names):
     """
     Find docstring cross references that fail to resolve.
 
-    @type names:
+    :type names:
       Sequence of module names or filenames.
-    @return:
-      Sequence of C{(module, linenos, container_name, identifier)} tuples.
+    :return:
+      Sequence of ``(module, linenos, container_name, identifier)`` tuples.
     """
     xrs = XrefScanner(names)
     return xrs.scan()

--- a/lib/python/pyflyby/_file.py
+++ b/lib/python/pyflyby/_file.py
@@ -92,10 +92,10 @@ class Filename(object):
     def ext(self):
         """
         Returns the extension of this filename, including the dot.
-        Returns C{None} if no extension.
+        Returns ``None`` if no extension.
 
-        @rtype:
-          C{str} or C{None}
+        :rtype:
+          ``str`` or ``None``
         """
         lhs, dot, rhs = self._filename.rpartition('.')
         if not dot:
@@ -167,8 +167,8 @@ class Filename(object):
           >>> Filename("/aa/bb").ancestors
           (Filename('/aa/bb'), Filename('/aa'), Filename('/'))
 
-        @rtype:
-          C{tuple} of C{Filename}s
+        :rtype:
+          ``tuple`` of ``Filename`` s
         """
         result = [self]
         while True:
@@ -195,14 +195,14 @@ def _get_PATH():
 
 def which(program):
     """
-    Find C{program} on $PATH.
+    Find ``program`` on $PATH.
 
-    @type program:
-      C{str}
-    @rtype:
-      L{Filename}
-    @return:
-      Program on $PATH, or C{None} if not found.
+    :type program:
+      ``str``
+    :rtype:
+      `Filename`
+    :return:
+      Program on $PATH, or ``None`` if not found.
     """
     if "/" in program:
         raise ValueError("which(): input should be a basename")
@@ -223,7 +223,7 @@ Filename.STDIN = Filename("/dev/stdin")
 @total_ordering
 class FilePos(object):
     """
-    A (lineno, colno) position within a L{FileText}.
+    A (lineno, colno) position within a `FileText`.
     Both lineno and colno are 1-indexed.
     """
 
@@ -270,14 +270,14 @@ class FilePos(object):
 
     def __add__(self, delta):
         '''
-        "Add" a coordinate (line,col) delta to this C{FilePos}.
+        "Add" a coordinate (line,col) delta to this ``FilePos``.
 
         Note that addition here may be a non-obvious.  If there is any line
         movement, then the existing column number is ignored, and the new
         column is the new column delta + 1 (to convert into 1-based numbers).
 
-        @rtype:
-          L{FilePos}
+        :rtype:
+          `FilePos`
         '''
         ldelta, cdelta = self._intint(delta)
         assert ldelta >= 0 and cdelta >= 0
@@ -337,26 +337,26 @@ class FileText(object):
 
     def __new__(cls, arg, filename=None, startpos=None):
         """
-        Return a new C{FileText} instance.
+        Return a new ``FileText`` instance.
 
-        @type arg:
-          C{FileText}, C{Filename}, C{str}, or tuple of C{str}
-        @param arg:
+        :type arg:
+          ``FileText``, ``Filename``, ``str``, or tuple of ``str``
+        :param arg:
           If a sequence of lines, then each should end with a newline and have
           no other newlines.  Otherwise, something that can be interpreted or
           converted into a sequence of lines.
-        @type filename:
-          L{Filename}
-        @param filename:
-          Filename to attach to this C{FileText}, if not already given by
-          C{arg}.
-        @type startpos:
-          C{FilePos}
-        @param startpos:
-          Starting file position (lineno & colno) of this C{FileText}, if not
-          already given by C{arg}.
-        @rtype:
-          C{FileText}
+        :type filename:
+          `Filename`
+        :param filename:
+          Filename to attach to this ``FileText``, if not already given by
+          ``arg``.
+        :type startpos:
+          ``FilePos``
+        :param startpos:
+          Starting file position (lineno & colno) of this ``FileText``, if not
+          already given by ``arg``.
+        :rtype:
+          ``FileText``
         """
         if isinstance(arg, cls):
             if filename is startpos is None:
@@ -402,8 +402,8 @@ class FileText(object):
         string.  This is to avoid having to check lines[-1].endswith('\n')
         everywhere.
 
-        @rtype:
-          C{tuple} of C{str}
+        :rtype:
+          ``tuple`` of ``str``
         """
         # Used if only initialized with 'joined'.
         # We use str.split() instead of str.splitlines() because the latter
@@ -443,8 +443,8 @@ class FileText(object):
         """
         The position after the last character in the text.
 
-        @rtype:
-          C{FilePos}
+        :rtype:
+          ``FilePos``
         """
         startpos = self.startpos
         lines    = self.lines
@@ -483,9 +483,9 @@ class FileText(object):
     def __getitem__(self, arg):
         """
         Return the line(s) with the given line number(s).
-        If slicing, returns an instance of C{FileText}.
+        If slicing, returns an instance of ``FileText``.
 
-        Note that line numbers are indexed based on C{self.startpos.lineno}
+        Note that line numbers are indexed based on ``self.startpos.lineno``
         (which is 1 at the start of the file).
 
           >>> FileText("a\\nb\\nc\\nd")[2]
@@ -496,18 +496,19 @@ class FileText(object):
 
           >>> FileText("a\\nb\\nc\\nd")[0]
           Traceback (most recent call last):
+
             ...
           IndexError: Line number 0 out of range [1, 4)
 
-        When slicing, the input arguments can also be given as C{FilePos}
+        When slicing, the input arguments can also be given as ``FilePos``
         arguments or (lineno,colno) tuples.  These are 1-indexed at the start
         of the file.
 
           >>> FileText("a\\nb\\nc\\nd")[(2,2):4]
           FileText('\\nc\\n', startpos=(2,2))
 
-        @rtype:
-          C{str} or L{FileText}
+        :rtype:
+          ``str`` or `FileText`
         """
         L = self._lineno_to_index
         C = self._colno_to_index
@@ -574,11 +575,11 @@ class FileText(object):
     @classmethod
     def concatenate(cls, args):
         """
-        Concatenate a bunch of L{FileText} arguments.  Uses the C{filename}
-        and C{startpos} from the first argument.
+        Concatenate a bunch of `FileText` arguments.  Uses the ``filename``
+        and ``startpos`` from the first argument.
 
-        @rtype:
-          L{FileText}
+        :rtype:
+          `FileText`
         """
         args = [FileText(x) for x in args]
         if len(args) == 1:
@@ -668,15 +669,15 @@ def expand_py_files_from_args(pathnames, on_error=lambda filename: None):
     Arguments that are files are always included.
     Arguments that are directories are recursively searched for *.py files.
 
-    @type pathnames:
-      C{list} of L{Filename}s
-    @type on_error:
+    :type pathnames:
+      ``list`` of `Filename` s
+    :type on_error:
       callable
-    @param on_error:
-      Function that is called for arguments directly specified in C{pathnames}
+    :param on_error:
+      Function that is called for arguments directly specified in ``pathnames``
       that don't exist or are otherwise inaccessible.
-    @rtype:
-      C{list} of L{Filename}s
+    :rtype:
+      ``list`` of `Filename` s
     """
     if not isinstance(pathnames, (tuple, list)):
         pathnames = [pathnames]

--- a/lib/python/pyflyby/_flags.py
+++ b/lib/python/pyflyby/_flags.py
@@ -39,10 +39,11 @@ class CompilerFlags(int):
       CompilerFlags(0x18000) # from __future__ import with_statement, print_function
 
     This can be used as an argument to the built-in compile() function. For
-    instance, in Python 2:
+    instance, in Python 2::
 
       >>> compile("print('x', file=None)", "?", "exec", flags=0, dont_inherit=1) #doctest:+SKIP
       Traceback (most recent call last):
+
         ...
       SyntaxError: invalid syntax
 
@@ -53,13 +54,13 @@ class CompilerFlags(int):
 
     def __new__(cls, *args):
         """
-        Construct a new C{CompilerFlags} instance.
+        Construct a new ``CompilerFlags`` instance.
 
-        @param args:
-          Any number (zero or more) C{CompilerFlags}s, C{int}s, or C{str}s,
+        :param args:
+          Any number (zero or more) ``CompilerFlags`` s, ``int`` s, or ``str`` s,
           which are bitwise-ORed together.
-        @rtype:
-          L{CompilerFlags}
+        :rtype:
+          `CompilerFlags`
         """
         if len(args) == 0:
             return cls._ZERO
@@ -109,10 +110,10 @@ class CompilerFlags(int):
         """
         Parse the compiler flags from AST node(s).
 
-        @type nodes:
-          C{ast.AST} or sequence thereof
-        @rtype:
-          C{CompilerFlags}
+        :type nodes:
+          ``ast.AST`` or sequence thereof
+        :rtype:
+          ``CompilerFlags``
         """
         if isinstance(nodes, ast.Module):
             nodes = nodes.body

--- a/lib/python/pyflyby/_format.py
+++ b/lib/python/pyflyby/_format.py
@@ -42,29 +42,29 @@ def fill(tokens, sep=(", ", ""), prefix="", suffix="", newline="\n",
          max_line_length=80):
     r"""
     Given a sequences of strings, fill them into a single string with up to
-    C{max_line_length} characters each.
+    ``max_line_length`` characters each.
 
       >>> fill(["'hello world'", "'hello two'"],
       ...            prefix=("print ", "      "), suffix=(" \\", ""),
       ...            max_line_length=25)
       "print 'hello world', \\\n      'hello two'\n"
 
-    @param tokens:
+    :param tokens:
       Sequence of strings to fill.  There must be at least one token.
-    @param sep:
+    :param sep:
       Separator string to append to each token.  If a 2-element tuple, then
       indicates the separator between tokens and the separator after the last
       token.  Trailing whitespace is removed from each line before appending
       the suffix, but not from between tokens on the same line.
-    @param prefix:
+    :param prefix:
       String to prepend at the beginning of each line.  If a 2-element tuple,
       then indicates the prefix for the first line and prefix for subsequent
       lines.
-    @param suffix:
+    :param suffix:
       String to append to the end of each line.  If a 2-element tuple, then
       indicates the suffix for all lines except the last, and the suffix for
       the last line.
-    @return:
+    :return:
       Filled string.
     """
     N = max_line_length
@@ -116,14 +116,14 @@ def pyfill(prefix, tokens, params=FormatParams()):
           baz, quux,
           quuuuux)
 
-    @param prefix:
+    :param prefix:
       Prefix for first line.
-    @param tokens:
+    :param tokens:
       Sequence of string tokens
-    @type params:
-      L{FormatParams}
-    @rtype:
-      C{str}
+    :type params:
+      `FormatParams`
+    :rtype:
+      ``str``
     """
     N = params.max_line_length
     if params.wrap_paren:

--- a/lib/python/pyflyby/_idents.py
+++ b/lib/python/pyflyby/_idents.py
@@ -32,13 +32,13 @@ def dotted_prefixes(dotted_name, reverse=False):
       >>> dotted_prefixes("aa.bb.cc", reverse=True)
       ['aa.bb.cc', 'aa.bb', 'aa']
 
-    @type dotted_name:
-      C{str}
-    @param reverse:
+    :type dotted_name:
+      ``str``
+    :param reverse:
       If False (default), return shortest to longest.  If True, return longest
       to shortest.
-    @rtype:
-      C{list} of C{str}
+    :rtype:
+      ``list`` of ``str``
     """
     name_parts = dotted_name.split(".")
     if reverse:
@@ -56,7 +56,7 @@ _dotted_name_prefix_re = re.compile(r"[a-zA-Z_][a-zA-Z0-9_]*([.][a-zA-Z_][a-zA-Z
 
 def is_identifier(s, dotted=False, prefix=False):
     """
-    Return whether C{s} is a valid Python identifier name.
+    Return whether ``s`` is a valid Python identifier name.
 
       >>> is_identifier("foo")
       True
@@ -67,9 +67,9 @@ def is_identifier(s, dotted=False, prefix=False):
       >>> is_identifier("from")
       False
 
-    By default, we check whether C{s} is a single valid identifier, meaning
-    dots are not allowed.  If C{dotted=True}, then we check each dotted
-    component:
+    By default, we check whether ``s`` is a single valid identifier, meaning
+    dots are not allowed.  If ``dotted=True``, then we check each dotted
+    component::
 
       >>> is_identifier("foo.bar")
       False
@@ -84,7 +84,7 @@ def is_identifier(s, dotted=False, prefix=False):
       False
 
     By default, the string must comprise a valid identifier.  If
-    C{prefix=True}, then allow strings that are prefixes of valid identifiers.
+    ``prefix=True``, then allow strings that are prefixes of valid identifiers.
     Prefix=False excludes the empty string, strings with a trailing dot, and
     strings with a trailing keyword component, but prefix=True does not
     exclude these.
@@ -101,18 +101,18 @@ def is_identifier(s, dotted=False, prefix=False):
       >>> is_identifier("foo.or", dotted=True, prefix=True)
       True
 
-    @type s:
-      C{str}
-    @param dotted:
-      If C{False} (default), then the input must be a single name such as
-      "foo".  If C{True}, then the input can be a single name or a dotted name
+    :type s:
+      ``str``
+    :param dotted:
+      If ``False`` (default), then the input must be a single name such as
+      "foo".  If ``True``, then the input can be a single name or a dotted name
       such as "foo.bar.baz".
-    @param prefix:
-      If C{False} (Default), then the input must be a valid identifier.  If
-      C{True}, then the input can be a valid identifier or the prefix of a
+    :param prefix:
+      If ``False`` (Default), then the input must be a valid identifier.  If
+      ``True``, then the input can be a valid identifier or the prefix of a
       valid identifier.
-    @rtype:
-      C{bool}
+    :rtype:
+      ``bool``
     """
     if not isinstance(s, six.string_types):
         raise TypeError("is_identifier(): expected a string; got a %s"

--- a/lib/python/pyflyby/_importclns.py
+++ b/lib/python/pyflyby/_importclns.py
@@ -43,26 +43,26 @@ class ImportSet(object):
         from m3 import m4 as m34
       ''')
 
-    An C{ImportSet} is an immutable data structure.
+    An ``ImportSet`` is an immutable data structure.
     """
 
     def __new__(cls, arg, ignore_nonimports=False, ignore_shadowed=False):
         """
-        Return as an L{ImportSet}.
+        Return as an `ImportSet`.
 
-        @param ignore_nonimports:
-          If C{False}, complain about non-imports.  If C{True}, ignore
+        :param ignore_nonimports:
+          If ``False``, complain about non-imports.  If ``True``, ignore
           non-imports.
-        @param ignore_shadowed:
-          Whether to ignore shadowed imports.  If C{False}, then keep all
+        :param ignore_shadowed:
+          Whether to ignore shadowed imports.  If ``False``, then keep all
           unique imports, even if they shadow each other.  Note that an
-          C{ImportSet} is unordered; an C{ImportSet} with conflicts will only
+          ``ImportSet`` is unordered; an ``ImportSet`` with conflicts will only
           be useful for very specific cases (e.g. set of imports to forget
           from known-imports database), and not useful for outputting as code.
-          If C{ignore_shadowed} is C{True}, then earlier shadowed imports are
+          If ``ignore_shadowed`` is ``True``, then earlier shadowed imports are
           ignored.
-        @rtype:
-          L{ImportSet}
+        :rtype:
+          `ImportSet`
         """
         if isinstance(arg, cls):
             if ignore_shadowed:
@@ -77,12 +77,12 @@ class ImportSet(object):
     @classmethod
     def _from_imports(cls, imports, ignore_shadowed=False):
         """
-        @type imports:
-          Sequence of L{Import}s
-        @param ignore_shadowed:
-          See L{ImportSet.__new__}.
-        @rtype:
-          L{ImportSet}
+        :type imports:
+          Sequence of `Import` s
+        :param ignore_shadowed:
+          See `ImportSet.__new__`.
+        :rtype:
+          `ImportSet`
         """
         # Canonicalize inputs.
         imports = [Import(imp) for imp in imports]
@@ -106,16 +106,16 @@ class ImportSet(object):
     @classmethod
     def _from_args(cls, args, ignore_nonimports=False, ignore_shadowed=False):
         """
-        @type args:
-          C{tuple} or C{list} of L{ImportStatement}s, L{PythonStatement}s,
-          L{PythonBlock}s, L{FileText}, and/or L{Filename}s
-        @param ignore_nonimports:
-          If C{False}, complain about non-imports.  If C{True}, ignore
+        :type args:
+          ``tuple`` or ``list`` of `ImportStatement` s, `PythonStatement` s,
+          `PythonBlock` s, `FileText`, and/or `Filename` s
+        :param ignore_nonimports:
+          If ``False``, complain about non-imports.  If ``True``, ignore
           non-imports.
-        @param ignore_shadowed:
-          See L{ImportSet.__new__}.
-        @rtype:
-          L{ImportSet}
+        :param ignore_shadowed:
+          See `ImportSet.__new__`.
+        :rtype:
+          `ImportSet`
         """
         if not isinstance(args, (tuple, list)):
             args = [args]
@@ -124,10 +124,10 @@ class ImportSet(object):
         args = [a for a in args if a]
         if not args:
             return cls._EMPTY
-        # If we only got one C{ImportSet}, just return it.
+        # If we only got one ``ImportSet``, just return it.
         if len(args) == 1 and type(args[0]) is cls and not ignore_shadowed:
             return args[0]
-        # Collect all L{Import}s from arguments.
+        # Collect all `Import` s from arguments.
         imports = []
         for arg in args:
             if isinstance(arg, Import):
@@ -155,8 +155,8 @@ class ImportSet(object):
 
     def with_imports(self, other):
         """
-        Return a new L{ImportSet} that is the union of C{self} and
-        C{new_imports}.
+        Return a new `ImportSet` that is the union of ``self`` and
+        ``new_imports``.
 
           >>> impset = ImportSet('from m import t1, t2, t3')
           >>> impset.with_imports('import m.t2a as t2b')
@@ -164,10 +164,10 @@ class ImportSet(object):
             from m import t1, t2, t2a as t2b, t3
           ''')
 
-        @type other:
-          L{ImportSet} (or convertible)
-        @rtype:
-          L{ImportSet}
+        :type other:
+          `ImportSet` (or convertible)
+        :rtype:
+          `ImportSet`
         """
         other = ImportSet(other)
         return type(self)._from_imports(self._importset | other._importset)
@@ -182,10 +182,10 @@ class ImportSet(object):
             from m import t1, t2, t4
           ''')
 
-        @type removals:
-          L{ImportSet} (or convertible)
-        @rtype:
-          L{ImportSet}
+        :type removals:
+          `ImportSet` (or convertible)
+        :rtype:
+          `ImportSet`
         """
         removals = ImportSet(removals)
         if not removals:
@@ -212,7 +212,7 @@ class ImportSet(object):
     @cached_attribute
     def _by_module_name(self):
         """
-        @return:
+        :return:
           (mapping from name to __future__ imports,
            mapping from name to non-'from' imports,
            mapping from name to 'from' imports)
@@ -235,7 +235,7 @@ class ImportSet(object):
 
     def get_statements(self, separate_from_imports=True):
         """
-        Canonicalized L{ImportStatement}s.
+        Canonicalized `ImportStatement` s.
         These have been merged by module and sorted.
 
           >>> importset = ImportSet('''
@@ -255,8 +255,8 @@ class ImportSet(object):
           from _hello import there, world
           from d import dd as DD
 
-        @rtype:
-          C{tuple} of L{ImportStatement}s
+        :rtype:
+          ``tuple`` of `ImportStatement` s
         """
         groups = self._by_module_name
         if not separate_from_imports:
@@ -282,21 +282,21 @@ class ImportSet(object):
     @cached_attribute
     def statements(self):
         """
-        Canonicalized L{ImportStatement}s.
+        Canonicalized `ImportStatement` s.
         These have been merged by module and sorted.
 
-        @rtype:
-          C{tuple} of L{ImportStatement}s
+        :rtype:
+          ``tuple`` of `ImportStatement` s
         """
         return self.get_statements(separate_from_imports=True)
 
     @cached_attribute
     def imports(self):
         """
-        Canonicalized imports, in the same order as C{self.statements}.
+        Canonicalized imports, in the same order as ``self.statements``.
 
-        @rtype:
-          C{tuple} of L{Import}s
+        :rtype:
+          ``tuple`` of `Import` s
         """
         return tuple(
             imp
@@ -307,13 +307,13 @@ class ImportSet(object):
     @cached_attribute
     def by_import_as(self):
         """
-        Map from C{import_as} to L{Import}.
+        Map from ``import_as`` to `Import`.
 
           >>> ImportSet('from aa.bb import cc as dd').by_import_as
           {'dd': (Import('from aa.bb import cc as dd'),)}
 
-        @rtype:
-          C{dict} mapping from C{str} to tuple of L{Import}s
+        :rtype:
+          ``dict`` mapping from ``str`` to tuple of `Import` s
         """
         d = defaultdict(list)
         for imp in self._importset:
@@ -324,7 +324,7 @@ class ImportSet(object):
     @cached_attribute
     def member_names(self):
         r"""
-        Map from parent module/package C{fullname} to known member names.
+        Map from parent module/package ``fullname`` to known member names.
 
           >>> impset = ImportSet("import numpy.linalg.info\nfrom sys import exit as EXIT")
           >>> import pprint
@@ -336,8 +336,8 @@ class ImportSet(object):
 
         This is used by the autoimporter module for implementing tab completion.
 
-        @rtype:
-          C{dict} mapping from C{str} to tuple of C{str}
+        :rtype:
+          ``dict`` mapping from ``str`` to tuple of ``str``
         """
         d = defaultdict(set)
         for imp in self._importset:
@@ -362,8 +362,8 @@ class ImportSet(object):
           >>> ImportSet('import b\nfrom f import a\n').conflicting_imports
           ()
 
-        @rtype:
-          C{bool}
+        :rtype:
+          ``bool``
         """
         return tuple(
             k
@@ -388,10 +388,10 @@ class ImportSet(object):
         """
         Pretty-print a block of import statements into a single string.
 
-        @type params:
-          L{ImportFormatParams}
-        @rtype:
-          C{str}
+        :type params:
+          `ImportFormatParams`
+        :rtype:
+          ``str``
         """
         params = ImportFormatParams(params)
         # TODO: instead of complaining about conflicts, just filter out the
@@ -520,7 +520,7 @@ class ImportMap(object):
       >>> ImportMap({'a.b': 'aa.bb', 'a.b.c': 'aa.bb.cc'})
       ImportMap({'a.b': 'aa.bb', 'a.b.c': 'aa.bb.cc'})
 
-    An C{ImportMap} is an immutable data structure.
+    An ``ImportMap`` is an immutable data structure.
     """
 
     def __new__(cls, arg):

--- a/lib/python/pyflyby/_importdb.py
+++ b/lib/python/pyflyby/_importdb.py
@@ -36,7 +36,7 @@ def _find_etc_dir():
 
 def _get_env_var(env_var_name, default):
     '''
-    Get an environment variable and split on ":", replacing C{-} with the
+    Get an environment variable and split on ":", replacing ``-`` with the
     default.
     '''
     assert re.match("^[A-Z_]+$", env_var_name)
@@ -44,7 +44,7 @@ def _get_env_var(env_var_name, default):
     value = list(filter(None, os.environ.get(env_var_name, '').split(':')))
     if not value:
         return default
-    # Replace '-' with C{default}
+    # Replace '-' with ``default``
     try:
         idx = value.index('-')
     except ValueError:
@@ -58,14 +58,14 @@ def _get_python_path(env_var_name, default_path, target_dirname):
     '''
     Expand an environment variable specifying pyflyby input config files.
 
-      - Default to C{default_path} if the environment variable is undefined.
+      - Default to ``default_path`` if the environment variable is undefined.
       - Process colon delimiters.
-      - Replace "-" with C{default_path}.
+      - Replace "-" with ``default_path``.
       - Expand triple dots.
       - Recursively traverse directories.
 
-    @rtype:
-      C{tuple} of C{Filename}s
+    :rtype:
+      ``tuple`` of ``Filename`` s
     '''
     pathnames = _get_env_var(env_var_name, default_path)
     if pathnames == ["EMPTY"]:
@@ -106,17 +106,18 @@ def _get_st_dev(filename):
 
 def _ancestors_on_same_partition(filename):
     """
-    Generate ancestors of C{filename} that exist and are on the same partition
-    as the first existing ancestor of C{filename}.
+    Generate ancestors of ``filename`` that exist and are on the same partition
+    as the first existing ancestor of ``filename``.
 
     For example, suppose a partition is mounted on /u/homer; /u is a different
     partition.  Suppose /u/homer/aa exists but /u/homer/aa/bb does not exist.
     Then::
+
       >> _ancestors_on_same_partition("/u/homer/aa/bb/cc")
       [Filename("/u/homer", Filename("/u/homer/aa")]
 
-    @rtype:
-      C{list} of C{Filename}
+    :rtype:
+      ``list`` of ``Filename``
     """
     result = []
     dev = None
@@ -134,21 +135,22 @@ def _ancestors_on_same_partition(filename):
 
 def _expand_tripledots(pathnames, target_dirname):
     """
-    Expand pathnames of the form C{".../foo/bar"} as "../../foo/bar",
+    Expand pathnames of the form ``".../foo/bar"`` as "../../foo/bar",
     "../foo/bar", "./foo/bar" etc., up to the oldest ancestor with the same
     st_dev.
 
     For example, suppose a partition is mounted on /u/homer; /u is a different
     partition.  Then::
+
       >> _expand_tripledots(["/foo", ".../tt"], "/u/homer/aa")
       [Filename("/foo"), Filename("/u/homer/tt"), Filename("/u/homer/aa/tt")]
 
-    @type pathnames:
-      sequence of C{str} (not C{Filename})
-    @type target_dirname:
-      L{Filename}
-    @rtype:
-      C{list} of L{Filename}
+    :type pathnames:
+      sequence of ``str`` (not ``Filename``)
+    :type target_dirname:
+      `Filename`
+    :rtype:
+      ``list`` of `Filename`
     """
     target_dirname = Filename(target_dirname)
     if not isinstance(pathnames, (tuple, list)):
@@ -228,13 +230,13 @@ class ImportDB(object):
 
         Memoized.
 
-        @param target_filename:
+        :param target_filename:
           The target filename for which to get the import database.  Note that
           the target filename itself is not read.  Instead, the target
           filename is relevant because we look for .../.pyflyby based on the
           target filename.
-        @rtype:
-          L{ImportDB}
+        :rtype:
+          `ImportDB`
         """
         # We're going to canonicalize target_filenames in a number of steps.
         # At each step, see if we've seen the input so far.  We do the cache
@@ -362,7 +364,7 @@ class ImportDB(object):
     @classmethod
     def _from_args(cls, args):
         # TODO: support merging input ImportDBs.  For now we support
-        # L{PythonBlock}s and convertibles such as L{Filename}.
+        # `PythonBlock` s and convertibles such as `Filename`.
         return cls._from_code(args)
 
     @classmethod
@@ -400,8 +402,8 @@ class ImportDB(object):
             ]
           ''')
 
-        @rtype:
-          L{ImportDB}
+        :rtype:
+          `ImportDB`
         """
         if not isinstance(blocks, (tuple, list)):
             blocks = [blocks]
@@ -455,12 +457,12 @@ class ImportDB(object):
         This function exists to support deprecated behavior.
         When we stop supporting the old behavior, we will delete this function.
 
-        @type filenames:
-          Sequence of L{Filename}s
-        @param filenames:
+        :type filenames:
+          Sequence of `Filename` s
+        :param filenames:
           Filenames of files to read.
-        @rtype:
-          L{ImportDB}
+        :rtype:
+          `ImportDB`
         """
         if not isinstance(filenames, (tuple, list)):
             filenames = [filenames]
@@ -526,7 +528,7 @@ class ImportDB(object):
     @cached_attribute
     def by_fullname_or_import_as(self):
         """
-        Map from C{fullname} and C{import_as} to L{Import}s.
+        Map from ``fullname`` and ``import_as`` to `Import` s.
 
           >>> import pprint
           >>> db = ImportDB('from aa.bb import cc as dd')
@@ -535,8 +537,8 @@ class ImportDB(object):
            'aa.bb': (Import('import aa.bb'),),
            'dd': (Import('from aa.bb import cc as dd'),)}
 
-        @rtype:
-          C{dict} mapping from C{str} to tuple of L{Import}s
+        :rtype:
+          ``dict`` mapping from ``str`` to tuple of `Import` s
         """
         # TODO: make known_imports take into account the below forget_imports,
         # then move this function into ImportSet

--- a/lib/python/pyflyby/_imports2s.py
+++ b/lib/python/pyflyby/_imports2s.py
@@ -42,10 +42,10 @@ class SourceToSourceTransformationBase(object):
 
     def output(self, params=None):
         """
-        Pretty-print and return as a L{PythonBlock}.
+        Pretty-print and return as a `PythonBlock`.
 
-        @rtype:
-          L{PythonBlock}
+        :rtype:
+          `PythonBlock`
         """
         result = self.pretty_print(params=params)
         result = PythonBlock(result, filename=self.input.filename)
@@ -104,10 +104,10 @@ class SourceToSourceFileImportsTransformation(SourceToSourceTransformationBase):
         """
         Find the import block containing the given line number.
 
-        @type lineno:
-          C{int}
-        @rtype:
-          L{SourceToSourceImportBlockTransformation}
+        :type lineno:
+          ``int``
+        :rtype:
+          `SourceToSourceImportBlockTransformation`
         """
         results = [
             b
@@ -123,10 +123,10 @@ class SourceToSourceFileImportsTransformation(SourceToSourceTransformationBase):
         """
         Remove the given import.
 
-        @type imp:
-          L{Import}
-        @type lineno:
-          C{int}
+        :type imp:
+          `Import`
+        :type lineno:
+          ``int``
         """
         block = self.find_import_block_by_lineno(lineno)
         try:
@@ -142,16 +142,16 @@ class SourceToSourceFileImportsTransformation(SourceToSourceTransformationBase):
 
     def select_import_block_by_closest_prefix_match(self, imp, max_lineno):
         """
-        Heuristically pick an import block that C{imp} "fits" best into.  The
+        Heuristically pick an import block that ``imp`` "fits" best into.  The
         selection is based on the block that contains the import with the
         longest common prefix.
 
-        @type imp:
-          L{Import}
-        @param max_lineno:
-          Only return import blocks earlier than C{max_lineno}.
-        @rtype:
-          L{SourceToSourceImportBlockTransformation}
+        :type imp:
+          `Import`
+        :param max_lineno:
+          Only return import blocks earlier than ``max_lineno``.
+        :rtype:
+          `SourceToSourceImportBlockTransformation`
         """
         # Create a data structure that annotates blocks with data by which
         # we'll sort.
@@ -226,10 +226,10 @@ class SourceToSourceFileImportsTransformation(SourceToSourceTransformationBase):
         add to, or if none found, creates a new one near the beginning of the
         module.
 
-        @type imp:
-          L{Import}
-        @param lineno:
-          Line before which to add the import.  C{Inf} means no constraint.
+        :type imp:
+          `Import`
+        :param lineno:
+          Line before which to add the import.  ``Inf`` means no constraint.
         """
         try:
             block = self.select_import_block_by_closest_prefix_match(
@@ -263,12 +263,12 @@ def reformat_import_statements(codeblock, params=None):
       from foo import bar0
       <BLANKLINE>
 
-    @type codeblock:
-      L{PythonBlock} or convertible (C{str})
-    @type params:
-      L{ImportFormatParams}
-    @rtype:
-      L{PythonBlock}
+    :type codeblock:
+      `PythonBlock` or convertible (``str``)
+    :type params:
+      `ImportFormatParams`
+    :rtype:
+      `PythonBlock`
     """
     params = ImportFormatParams(params)
     transformer = SourceToSourceFileImportsTransformation(codeblock)
@@ -277,11 +277,11 @@ def reformat_import_statements(codeblock, params=None):
 
 def ImportPathForRelativeImportsCtx(codeblock):
     """
-    Context manager that temporarily modifies C{sys.path} so that relative
-    imports for the given C{codeblock} work as expected.
+    Context manager that temporarily modifies ``sys.path`` so that relative
+    imports for the given ``codeblock`` work as expected.
 
-    @type codeblock:
-      L{PythonBlock}
+    :type codeblock:
+      `PythonBlock`
     """
     codeblock = PythonBlock(codeblock)
     if not codeblock.filename:
@@ -302,8 +302,8 @@ def fix_unused_and_missing_imports(codeblock,
 
     Also formats imports.
 
-    In the example below, C{m1} and C{m3} are unused, so are automatically
-    removed.  C{np} was undefined, so an C{import numpy as np} was
+    In the example below, ``m1`` and ``m3`` are unused, so are automatically
+    removed.  ``np`` was undefined, so an ``import numpy as np`` was
     automatically added.
 
       >>> codeblock = PythonBlock(
@@ -318,10 +318,10 @@ def fix_unused_and_missing_imports(codeblock,
       from foo import m2, m4
       m2, m4, np.foo
 
-    @type codeblock:
-      L{PythonBlock} or convertible (C{str})
-    @rtype:
-      L{PythonBlock}
+    :type codeblock:
+      `PythonBlock` or convertible (``str``)
+    :rtype:
+      `PythonBlock`
     """
     codeblock = PythonBlock(codeblock)
     if remove_unused == "AUTOMATIC":
@@ -420,10 +420,10 @@ def remove_broken_imports(codeblock, params=None):
 
     Also formats imports.
 
-    @type codeblock:
-      L{PythonBlock} or convertible (C{str})
-    @rtype:
-      L{PythonBlock}
+    :type codeblock:
+      `PythonBlock` or convertible (``str``)
+    :rtype:
+      `PythonBlock`
     """
     codeblock = PythonBlock(codeblock)
     params = ImportFormatParams(params)
@@ -446,32 +446,34 @@ def remove_broken_imports(codeblock, params=None):
 def replace_star_imports(codeblock, params=None):
     r"""
     Replace lines such as::
+
       from foo.bar import *
     with
       from foo.bar import f1, f2, f3
 
-    Note that this requires involves actually importing C{foo.bar}, which may
+    Note that this requires involves actually importing ``foo.bar``, which may
     have side effects.  (TODO: rewrite to avoid this?)
 
-    The result includes all imports from the C{email} module.  The result
+    The result includes all imports from the ``email`` module.  The result
     excludes shadowed imports.  In this example:
-      1. The original C{MIMEAudio} import is shadowed, so it is removed.
-      2. The C{MIMEImage} import in the C{email} module is shadowed by a
-         subsequent import, so it is omitted.
 
-      >>> codeblock = PythonBlock('from keyword import *', filename="/tmp/x.py")
+        1. The original ``MIMEAudio`` import is shadowed, so it is removed.
+        2. The ``MIMEImage`` import in the ``email`` module is shadowed by a
+           subsequent import, so it is omitted.
 
-      >>> print(replace_star_imports(codeblock))
-      [PYFLYBY] /tmp/x.py: replaced 'from keyword import *' with 2 imports
-      from keyword import iskeyword, kwlist
-      <BLANKLINE>
+        >>> codeblock = PythonBlock('from keyword import *', filename="/tmp/x.py")
+
+        >>> print(replace_star_imports(codeblock))
+        [PYFLYBY] /tmp/x.py: replaced 'from keyword import *' with 2 imports
+        from keyword import iskeyword, kwlist
+        <BLANKLINE>
 
     Usually you'll want to remove unused imports after replacing star imports.
 
-    @type codeblock:
-      L{PythonBlock} or convertible (C{str})
-    @rtype:
-      L{PythonBlock}
+    :type codeblock:
+      `PythonBlock` or convertible (``str``)
+    :rtype:
+      `PythonBlock`
     """
     from pyflyby._modules import ModuleHandle
     params = ImportFormatParams(params)
@@ -479,8 +481,8 @@ def replace_star_imports(codeblock, params=None):
     filename = codeblock.filename
     transformer = SourceToSourceFileImportsTransformation(codeblock)
     for block in transformer.import_blocks:
-        # Iterate over the import statements in C{block.input}.  We do this
-        # instead of using C{block.importset} because the latter doesn't
+        # Iterate over the import statements in ``block.input``.  We do this
+        # instead of using ``block.importset`` because the latter doesn't
         # preserve the order of inputs.  The order is important for
         # determining what's shadowed.
         imports = [
@@ -535,7 +537,7 @@ def replace_star_imports(codeblock, params=None):
 
 def transform_imports(codeblock, transformations, params=None):
     """
-    Transform imports as specified by C{transformations}.
+    Transform imports as specified by ``transformations``.
 
     transform_imports() perfectly replaces all imports in top-level import
     blocks.
@@ -549,14 +551,14 @@ def transform_imports(codeblock, transformations, params=None):
       >>> print(result.text.joined.strip())
       from m.y import z as x
 
-    @type codeblock:
-      L{PythonBlock} or convertible (C{str})
-    @type transformations:
-      C{dict} from C{str} to C{str}
-    @param transformations:
+    :type codeblock:
+      `PythonBlock` or convertible (``str``)
+    :type transformations:
+      ``dict`` from ``str`` to ``str``
+    :param transformations:
       A map of import prefixes to replace, e.g. {"aa.bb": "xx.yy"}
-    @rtype:
-      L{PythonBlock}
+    :rtype:
+      `PythonBlock`
     """
     codeblock = PythonBlock(codeblock)
     params = ImportFormatParams(params)
@@ -589,13 +591,13 @@ def transform_imports(codeblock, transformations, params=None):
 
 def canonicalize_imports(codeblock, params=None, db=None):
     """
-    Transform C{codeblock} as specified by C{__canonical_imports__} in the
+    Transform ``codeblock`` as specified by ``__canonical_imports__`` in the
     global import library.
 
-    @type codeblock:
-      L{PythonBlock} or convertible (C{str})
-    @rtype:
-      L{PythonBlock}
+    :type codeblock:
+      `PythonBlock` or convertible (``str``)
+    :rtype:
+      `PythonBlock`
     """
     codeblock = PythonBlock(codeblock)
     params = ImportFormatParams(params)

--- a/lib/python/pyflyby/_importstmt.py
+++ b/lib/python/pyflyby/_importstmt.py
@@ -20,7 +20,7 @@ from   pyflyby._util            import (Inf, cached_attribute, cmp,
 class ImportFormatParams(FormatParams):
     align_imports = True
     """
-    Whether and how to align 'from modulename import aliases...'.  If C{True},
+    Whether and how to align 'from modulename import aliases...'.  If ``True``,
     then the 'import' keywords will be aligned within a block.  If an integer,
     then the 'import' keyword will always be at that column.  They will be
     wrapped if necessary.
@@ -34,8 +34,8 @@ class ImportFormatParams(FormatParams):
     separate_from_imports = True
     """
     Whether all 'from ... import ...' in an import block should come after
-    'import ...' statements.  C{separate_from_imports = False} works well with
-    C{from_spaces = 3}.  ('from __future__ import ...' always comes first.)
+    'import ...' statements.  ``separate_from_imports = False`` works well with
+    ``from_spaces = 3``.  ('from __future__ import ...' always comes first.)
     """
 
     align_future = False
@@ -55,9 +55,10 @@ ImportSplit = namedtuple("ImportSplit",
                          "module_name member_name import_as")
 """
 Representation of a single import at the token level::
+
   from [...]<module_name> import <member_name> as <import_as>
 
-If <module_name> is C{None}, then there is no "from" clause; instead just::
+If <module_name> is ``None``, then there is no "from" clause; instead just::
   import <member_name> as <import_as>
 """
 
@@ -114,10 +115,10 @@ class Import(object):
     @classmethod
     def _from_statement(cls, statement):
         """
-        @type statement:
-          L{ImportStatement} or convertible (L{PythonStatement}, C{str})
-        @rtype:
-          L{Import}
+        :type statement:
+          `ImportStatement` or convertible (`PythonStatement`, ``str``)
+        :rtype:
+          `Import`
         """
         statement = ImportStatement(statement)
         imports = statement.imports
@@ -137,8 +138,8 @@ class Import(object):
           >>> Import._from_identifier_or_statement('import foo.bar.baz')
           Import('import foo.bar.baz')
 
-        @rtype:
-          L{Import}
+        :rtype:
+          `Import`
         """
         if is_identifier(arg, dotted=True):
             return cls.from_parts(arg, arg.split('.')[-1])
@@ -148,12 +149,12 @@ class Import(object):
     @cached_attribute
     def split(self):
         """
-        Split this L{Import} into a C{ImportSplit} which represents the
-        token-level C{module_name}, C{member_name}, C{import_as}.
+        Split this `Import` into a ``ImportSplit`` which represents the
+        token-level ``module_name``, ``member_name``, ``import_as``.
 
-        Note that at the token level, C{import_as} can be C{None} to represent
+        Note that at the token level, ``import_as`` can be ``None`` to represent
         that the import statement doesn't have an "as ..." clause, whereas the
-        C{import_as} attribute on an C{Import} object is never C{None}.
+        ``import_as`` attribute on an ``Import`` object is never ``None``.
 
           >>> Import.from_parts(".foo.bar", "bar").split
           ImportSplit(module_name='.foo', member_name='bar', import_as=None)
@@ -167,8 +168,8 @@ class Import(object):
           >>> Import.from_parts("foo.bar", "foo.bar").split
           ImportSplit(module_name=None, member_name='foo.bar', import_as=None)
 
-        @rtype:
-          L{ImportSplit}
+        :rtype:
+          `ImportSplit`
         """
         if self.import_as == self.fullname:
             return ImportSplit(None, self.fullname, None)
@@ -193,11 +194,11 @@ class Import(object):
     @classmethod
     def from_split(cls, impsplit):
         """
-        Construct an L{Import} instance from C{module_name}, C{member_name},
-        C{import_as}.
+        Construct an `Import` instance from ``module_name``, ``member_name``,
+        ``import_as``.
 
-        @rtype:
-          L{Import}
+        :rtype:
+          `Import`
         """
         impsplit = ImportSplit(*impsplit)
         module_name, member_name, import_as = impsplit
@@ -218,15 +219,15 @@ class Import(object):
 
     def prefix_match(self, imp):
         """
-        Return the longest common prefix between C{self} and C{imp}.
+        Return the longest common prefix between ``self`` and ``imp``.
 
           >>> Import("import ab.cd.ef").prefix_match(Import("import ab.cd.xy"))
           ('ab', 'cd')
 
-        @type imp:
-          L{Import}
-        @rtype:
-          C{tuple} of C{str}
+        :type imp:
+          `Import`
+        :rtype:
+          ``tuple`` of ``str``
         """
         imp = Import(imp)
         n1 = self.fullname.split('.')
@@ -235,7 +236,7 @@ class Import(object):
 
     def replace(self, prefix, replacement):
         """
-        Return a new C{Import} that replaces C{prefix} with C{replacement}.
+        Return a new ``Import`` that replaces ``prefix`` with ``replacement``.
 
           >>> Import("from aa.bb import cc").replace("aa.bb", "xx.yy")
           Import('from xx.yy import cc')
@@ -243,8 +244,8 @@ class Import(object):
           >>> Import("from aa import bb").replace("aa.bb", "xx.yy")
           Import('from xx import yy as bb')
 
-        @rtype:
-          C{Import}
+        :rtype:
+          ``Import``
         """
         prefix_parts = prefix.split('.')
         replacement_parts = replacement.split('.')
@@ -316,8 +317,8 @@ class Import(object):
 class ImportStatement(object):
     """
     Token-level representation of an import statement containing multiple
-    imports from a single module.  Corresponds to an C{ast.ImportFrom} or
-    C{ast.Import}.
+    imports from a single module.  Corresponds to an ``ast.ImportFrom`` or
+    ``ast.Import``.
     """
     def __new__(cls, arg):
         if isinstance(arg, cls):
@@ -375,10 +376,10 @@ class ImportStatement(object):
           >>> ImportStatement._from_statement("from .  import bar, bar2")
           ImportStatement('from . import bar, bar2')
 
-        @type statement:
-          L{PythonStatement}
-        @rtype:
-          L{ImportStatement}
+        :type statement:
+          `PythonStatement`
+        :rtype:
+          `ImportStatement`
         """
         statement = PythonStatement(statement)
         return cls._from_ast_node(statement.ast_node)
@@ -386,10 +387,10 @@ class ImportStatement(object):
     @classmethod
     def _from_ast_node(cls, node):
         """
-        Construct an L{ImportStatement} from an L{ast} node.
+        Construct an `ImportStatement` from an `ast` node.
 
-        @rtype:
-          L{ImportStatement}
+        :rtype:
+          `ImportStatement`
         """
         if isinstance(node, ast.ImportFrom):
             if isinstance(node.module, str):
@@ -412,13 +413,13 @@ class ImportStatement(object):
     @classmethod
     def _from_imports(cls, imports):
         """
-        Construct an L{ImportStatement} from a sequence of C{Import}s.  They
-        must all have the same C{fromname}.
+        Construct an `ImportStatement` from a sequence of ``Import`` s.  They
+        must all have the same ``fromname``.
 
-        @type imports:
-          Sequence of L{Import}s
-        @rtype:
-          L{ImportStatement}
+        :type imports:
+          Sequence of `Import` s
+        :rtype:
+          `ImportStatement`
         """
         if not all(isinstance(imp, Import) for imp in imports):
             raise TypeError
@@ -435,10 +436,10 @@ class ImportStatement(object):
     @cached_attribute
     def imports(self):
         """
-        Return a sequence of L{Import}s.
+        Return a sequence of `Import` s.
 
-        @rtype:
-          C{tuple} of L{Import}s
+        :rtype:
+          ``tuple`` of `Import` s
         """
         return tuple(
             Import.from_split((self.fromname, alias[0], alias[1]))
@@ -457,12 +458,12 @@ class ImportStatement(object):
         """
         Pretty-print into a single string.
 
-        @type params:
-          L{FormatParams}
-        @param modulename_ljust:
+        :type params:
+          `FormatParams`
+        :param modulename_ljust:
           Number of characters to left-justify the 'from' name.
-        @rtype:
-          C{str}
+        :rtype:
+          ``str``
         """
         s0 = ''
         s = ''

--- a/lib/python/pyflyby/_interactive.py
+++ b/lib/python/pyflyby/_interactive.py
@@ -58,9 +58,9 @@ def _get_or_create_ipython_terminal_app():
     """
     Create/get the singleton IPython terminal application.
 
-    @rtype:
-      C{TerminalIPythonApp}
-    @raise NoIPythonPackageError:
+    :rtype:
+      ``TerminalIPythonApp``
+    :raise NoIPythonPackageError:
       IPython is not installed in the system.
     """
     try:
@@ -92,12 +92,12 @@ def _get_or_create_ipython_terminal_app():
 
 def _app_is_initialized(app):
     """
-    Return whether C{app.initialize()} has been called.
+    Return whether ``app.initialize()`` has been called.
 
-    @type app:
-      L{IPython.Application}
-    @rtype:
-      C{bool}
+    :type app:
+      `IPython.Application`
+    :rtype:
+      ``bool``
     """
     # There's no official way to tell whether app.initialize() has been called
     # before.  We guess whether the app has been initialized by checking
@@ -166,7 +166,7 @@ class _IPython010TerminalApplication(object):
 
 class _DummyIPythonEmbeddedApp(object):
     """
-    Small wrapper around an L{InteractiveShellEmbed}.
+    Small wrapper around an `InteractiveShellEmbed`.
     """
 
     def __init__(self, shell):
@@ -178,9 +178,9 @@ def _get_or_create_ipython_kernel_app():
     """
     Create/get the singleton IPython kernel application.
 
-    @rtype:
-      C{callable}
-    @return:
+    :rtype:
+      ``callable``
+    :return:
       The function that can be called to start the kernel application.
     """
     import IPython
@@ -214,17 +214,17 @@ def _get_or_create_ipython_kernel_app():
 
 def get_ipython_terminal_app_with_autoimporter():
     """
-    Return an initialized C{TerminalIPythonApp}.
+    Return an initialized ``TerminalIPythonApp``.
 
-    If a C{TerminalIPythonApp} has already been created, then use it (whether
+    If a ``TerminalIPythonApp`` has already been created, then use it (whether
     we are inside that app or not).  If there isn't already one, then create
     one.  Enable the auto importer, if it hasn't already been enabled.  If the
     app hasn't been initialized yet, then initialize() it (but don't start()
     it).
 
-    @rtype:
-      C{TerminalIPythonApp}
-    @raise NoIPythonPackageError:
+    :rtype:
+      ``TerminalIPythonApp``
+    :raise NoIPythonPackageError:
       IPython is not installed in the system.
     """
     app = _get_or_create_ipython_terminal_app()
@@ -309,8 +309,8 @@ def _initialize_and_start_app_with_autoimporter(app, argv):
     """
     Initialize and start an IPython app, with autoimporting enabled.
 
-    @type app:
-      L{BaseIPythonApplication}
+    :type app:
+      `BaseIPythonApplication`
     """
     # Enable the auto importer.
     AutoImporter(app).enable()
@@ -439,8 +439,8 @@ def _generate_enabler_code():
     """
     Generate code for enabling the auto importer.
 
-    @rtype:
-      C{str}
+    :rtype:
+      ``str``
     """
     funcdef = (
         "import pyflyby\n"
@@ -480,7 +480,7 @@ def _generate_enabler_code():
 
 def _install_in_ipython_config_file_40():
     """
-    Implementation of L{install_in_ipython_config_file} for IPython 4.0+.
+    Implementation of `install_in_ipython_config_file` for IPython 4.0+.
     """
     import IPython
     ipython_dir = Filename(IPython.paths.get_ipython_dir())
@@ -550,7 +550,7 @@ def _install_in_ipython_config_file_40():
 
 def _install_in_ipython_config_file_012():
     """
-    Implementation of L{install_in_ipython_config_file} for IPython 0.12+.
+    Implementation of `install_in_ipython_config_file` for IPython 0.12+.
     Tested with IPython 0.12, 0.13, 1.0, 1.2, 2.0, 2.1, 2.2, 2.3, 2.4, 3.0,
     3.1, 3.2, 4.0.
     """
@@ -588,7 +588,7 @@ def _install_in_ipython_config_file_012():
 
 def _install_in_ipython_config_file_011():
     """
-    Implementation of L{install_in_ipython_config_file} for IPython 0.11.
+    Implementation of `install_in_ipython_config_file` for IPython 0.11.
     """
     import IPython
     ipython_dir = Filename(IPython.utils.path.get_ipython_dir())
@@ -615,7 +615,7 @@ def _install_in_ipython_config_file_011():
 
 def _install_in_ipython_config_file_010():
     """
-    Implementation of L{install_in_ipython_config_file} for IPython 0.10.
+    Implementation of `install_in_ipython_config_file` for IPython 0.10.
     """
     import IPython
     ipython_dir = Filename(IPython.genutils.get_ipython_dir())
@@ -642,13 +642,13 @@ def _install_in_ipython_config_file_010():
 
 def _ipython_in_multiline(ip):
     """
-    Return C{False} if the user has entered only one line of input so far,
-    including the current line, or C{True} if it is the second or later line.
+    Return ``False`` if the user has entered only one line of input so far,
+    including the current line, or ``True`` if it is the second or later line.
 
-    @type ip:
-      C{InteractiveShell}
-    @rtype:
-      C{bool}
+    :type ip:
+      ``InteractiveShell``
+    :rtype:
+      ``bool``
     """
     if hasattr(ip, "input_splitter"):
         # IPython 0.11+.  Tested with IPython 0.11, 0.12, 0.13, 1.0, 1.2, 2.0,
@@ -664,12 +664,13 @@ def _ipython_in_multiline(ip):
 
 def InterceptPrintsDuringPromptCtx(ip):
     """
-    Decorator that hooks our logger so that:
+    Decorator that hooks our logger so that::
+
       1. Before the first print, if any, print an extra newline.
       2. Upon context exit, if any lines were printed, redisplay the prompt.
 
-    @type ip:
-      C{InteractiveShell}
+    :type ip:
+      ``InteractiveShell``
     """
     if not ip:
         return NullCtx()
@@ -771,8 +772,8 @@ def _get_ipython_app():
 
     If there is a subapp, return it.
 
-    @rtype:
-      L{BaseIPythonApplication} or an object that mimics some of its behavior
+    :rtype:
+      `BaseIPythonApplication` or an object that mimics some of its behavior
     """
     try:
         IPython = sys.modules['IPython']
@@ -823,11 +824,11 @@ def _ipython_namespaces(ip):
 
     The ordering follows IPython convention of most-local to most-global.
 
-    @type ip:
-      C{InteractiveShell}
-    @rtype:
-      C{list}
-    @return:
+    :type ip:
+      ``InteractiveShell``
+    :rtype:
+      ``list``
+    :return:
       List of (name, namespace_dict) tuples.
     """
     # This list is copied from IPython 2.2's InteractiveShell._ofind().
@@ -865,8 +866,8 @@ def _get_pdb_if_is_in_pdb():
     """
     Return the current Pdb instance, if we're currently called from Pdb.
 
-    @rtype:
-      C{pdb.Pdb} or C{NoneType}
+    :rtype:
+      ``pdb.Pdb`` or ``NoneType``
     """
     # This is kludgy.  Todo: Is there a better way to do this?
     pframe, pkgname = _skip_frames(sys._getframe(1), _IS_PDB_IGNORE_PKGS)
@@ -919,12 +920,12 @@ def get_global_namespaces(ip):
     """
     Get the global interactive namespaces.
 
-    @type ip:
-      C{InteractiveShell}
-    @param ip:
-      IPython shell or C{None} to assume not in IPython.
-    @rtype:
-      C{list} of C{dict}
+    :type ip:
+      ``InteractiveShell``
+    :param ip:
+      IPython shell or ``None`` to assume not in IPython.
+    :rtype:
+      ``list`` of ``dict``
     """
     # logger.debug("get_global_namespaces()")
     pdb_instance = _get_pdb_if_is_in_pdb()
@@ -942,7 +943,7 @@ def get_global_namespaces(ip):
 def complete_symbol(fullname, namespaces, db=None, autoimported=None, ip=None,
                     allow_eval=False):
     """
-    Enumerate possible completions for C{fullname}.
+    Enumerate possible completions for ``fullname``.
 
     Includes globals and auto-importable symbols.
 
@@ -950,7 +951,7 @@ def complete_symbol(fullname, namespaces, db=None, autoimported=None, ip=None,
       [...'threading'...]
 
     Completion works on attributes, even on modules not yet imported - modules
-    are auto-imported first if not yet imported:
+    are auto-imported first if not yet imported::
 
       >>> ns = {}
       >>> complete_symbol("threading.Threa", namespaces=[ns])
@@ -967,31 +968,31 @@ def complete_symbol(fullname, namespaces, db=None, autoimported=None, ip=None,
     completed.  If the user asks to complete "foo.bar.quu<TAB>", we need to
     import foo.bar, but we don't need to import foo.bar.quux.
 
-    @type fullname:
-      C{str}
-    @param fullname:
+    :type fullname:
+      ``str``
+    :param fullname:
       String to complete.  ("Full" refers to the fact that it should contain
       dots starting from global level.)
-    @type namespaces:
-      C{dict} or C{list} of C{dict}
-    @param namespaces:
+    :type namespaces:
+      ``dict`` or ``list`` of ``dict``
+    :param namespaces:
       Namespaces of (already-imported) globals.
-    @type db:
-      L{importDB}
-    @param db:
+    :type db:
+      `importDB`
+    :param db:
       Import database to use.
-    @type ip:
-      C{InteractiveShell}
-    @param ip:
-      IPython shell instance if in IPython; C{None} to assume not in IPython.
-    @param allow_eval:
+    :type ip:
+      ``InteractiveShell``
+    :param ip:
+      IPython shell instance if in IPython; ``None`` to assume not in IPython.
+    :param allow_eval:
       Whether to allow evaluating code, which is necessary to allow completing
       e.g. 'foo[0].bar<TAB>' or 'foo().bar<TAB>'.  Note that IPython will only
       pass such strings if IPCompleter.greedy is configured to True by the
       user.
-    @rtype:
-      C{list} of C{str}
-    @return:
+    :rtype:
+      ``list`` of ``str``
+    :return:
       Completion candidates.
     """
     namespaces = ScopeStack(namespaces)
@@ -1002,7 +1003,7 @@ def complete_symbol(fullname, namespaces, db=None, autoimported=None, ip=None,
     # fullname) must be a prefix of a valid symbol.  Otherwise don't bother
     # generating completions.
     # As for the left-hand-side of the split, load_symbol() will validate it
-    # or evaluate it depending on C{allow_eval}.
+    # or evaluate it depending on ``allow_eval``.
     if not is_identifier(attrname, prefix=True):
         return []
     # Get the database of known imports.
@@ -1054,8 +1055,8 @@ def complete_symbol(fullname, namespaces, db=None, autoimported=None, ip=None,
             # Add known_imports entries from the database.
             results.update(known.member_names.get(pname, []))
             # Get the module handle.  Note that we use ModuleHandle() on the
-            # *name* of the module (C{pname}) instead of the module instance
-            # (C{parent}).  Using the module instance normally works, but
+            # *name* of the module (``pname``) instead of the module instance
+            # (``parent``).  Using the module instance normally works, but
             # breaks if the module hackily replaced itself with a pseudo
             # module (e.g. https://github.com/josiahcarlson/mprop).
             pmodule = ModuleHandle(pname)
@@ -1078,10 +1079,10 @@ def _list_members_for_completion(obj, ip):
 
     It does not include not-yet-imported submodules.
 
-    @param obj:
+    :param obj:
       Object whose member attributes to enumerate.
-    @rtype:
-      C{list} of C{str}
+    :rtype:
+      ``list`` of ``str``
     """
     if ip is None:
         words = dir(obj)
@@ -1210,8 +1211,8 @@ def new_IPdb_instance():
 
     Enable the auto importer.
 
-    @rtype:
-      L{Pdb}
+    :rtype:
+      `Pdb`
     """
     logger.debug("new_IPdb_instance()")
     try:
@@ -1239,12 +1240,12 @@ def _get_ipython_color_scheme(app):
     """
     Get the configured IPython color scheme.
 
-    @type app:
-      L{TerminalIPythonApp}
-    @param app:
+    :type app:
+      `TerminalIPythonApp`
+    :param app:
       An initialized IPython terminal application.
-    @rtype:
-      C{str}
+    :rtype:
+      ``str``
     """
     try:
         # Tested with IPython 0.11, 0.12, 0.13, 1.0, 1.1, 1.2, 2.0, 2.1, 2.2,
@@ -1270,7 +1271,7 @@ def print_verbose_tb(*exc_info):
     """
     Print a traceback, using IPython's ultraTB if possible.
 
-    @param exc_info:
+    :param exc_info:
       3 arguments as returned by sys.exc_info().
     """
     if not exc_info:
@@ -1371,8 +1372,8 @@ class AutoImporter(object):
         """
         Get the AutoImporter for the given app, or create and assign one.
 
-        @type arg:
-          L{AutoImporter}, L{BaseIPythonApplication}, L{InteractiveShell}
+        :type arg:
+          `AutoImporter`, `BaseIPythonApplication`, `InteractiveShell`
         """
         if isinstance(arg, AutoImporter):
             return arg
@@ -1386,7 +1387,7 @@ class AutoImporter(object):
         if "App" in clsname:
             return cls._from_app(arg)
         elif "Shell" in clsname:
-            # If given an C{InteractiveShell} argument, then get its parent app.
+            # If given an ``InteractiveShell`` argument, then get its parent app.
             # Tested with IPython 1.0, 1.2, 2.0, 2.1, 2.2, 2.3, 2.4, 3.0, 3.1,
             # 3.2, 4.0.
             if hasattr(arg, 'parent') and getattr(arg.parent, 'shell', None) is arg:
@@ -1422,10 +1423,10 @@ class AutoImporter(object):
     @classmethod
     def _construct(cls, app):
         """
-        Create a new AutoImporter for C{app}.
+        Create a new AutoImporter for ``app``.
 
-        @type app:
-          L{IPython.core.application.BaseIPythonApplication}
+        :type app:
+          `IPython.core.application.BaseIPythonApplication`
         """
         self = object.__new__(cls)
         self.app = app
@@ -1918,8 +1919,8 @@ class AutoImporter(object):
             # Tested with IPython 1.0, 1.2, 2.0, 2.3, 2.4, 3.0, 3.1, 3.2, 4.0.
             class _AutoImporter_ast_transformer(object):
                 """
-                A NodeVisitor-like wrapper around C{auto_import_for_ast} for
-                the API that IPython 1.x's C{ast_transformers} needs.
+                A NodeVisitor-like wrapper around ``auto_import_for_ast`` for
+                the API that IPython 1.x's ``ast_transformers`` needs.
                 """
                 def visit(self_, node):
                     # We don't actually transform the node; we just use
@@ -2489,7 +2490,7 @@ def enable_auto_importer(if_no_ipython='raise'):
     """
     Turn on the auto-importer in the current IPython application.
 
-    @param if_no_ipython:
+    :param if_no_ipython:
       If we are not inside IPython and if_no_ipython=='ignore', then silently
       do nothing.
       If we are not inside IPython and if_no_ipython=='raise', then raise
@@ -2528,19 +2529,21 @@ def load_ipython_extension(arg=Ellipsis):
     This function is used by IPython's extension mechanism.
 
     To load pyflyby in an existing IPython session, run::
+
       In [1]: %load_ext pyflyby
 
     To refresh the imports database (if you modified ~/.pyflyby), run::
+
       In [1]: %reload_ext pyflyby
 
     To load pyflyby automatically on IPython startup, appendto
     ~/.ipython/profile_default/ipython_config.py::
       c.InteractiveShellApp.extensions.append("pyflyby")
 
-    @type arg:
-      C{InteractiveShell}
-    @see:
-      U{http://ipython.org/ipython-doc/dev/config/extensions/index.html}
+    :type arg:
+      ``InteractiveShell``
+    :see:
+      http://ipython.org/ipython-doc/dev/config/extensions/index.html
     """
     logger.debug("load_ipython_extension() called for %s",
                  os.path.dirname(__file__))
@@ -2573,6 +2576,7 @@ def unload_ipython_extension(arg=Ellipsis):
     This function is used by IPython's extension mechanism.
 
     To unload interactively, run::
+
       In [1]: %unload_ext pyflyby
     """
     logger.debug("unload_ipython_extension() called for %s",

--- a/lib/python/pyflyby/_livepatch.py
+++ b/lib/python/pyflyby/_livepatch.py
@@ -13,21 +13,23 @@ This addresses cases where one module imported functions from another
 module.
 
 For example, suppose m1.py contains::
+
   from m2 import foo
   def print_foo():
       return foo()
 
 and m2.py contains::
+
   def foo():
       return 42
 
-If you edit m2.py and modify C{foo}, then reload(m2) on its own would not do
+If you edit m2.py and modify ``foo``, then reload(m2) on its own would not do
 what you want.  You would also need to reload(m1) after reload(m2).  This is
 because the built-in reload affects the module being reloaded, but references
 to the old module remain.  On the other hand, xreload() patches the existing
 m2.foo, so that live references to it are updated.
 
-In table form:
+In table form::
 
   Undesired effect:  reload(m2)
   Undesired effect:  reload(m1);  reload(m2)
@@ -44,6 +46,7 @@ xreload() really shines in that case.
 
 This implementation of xreload() was originally based the following
 mailing-list post by Guido van Rossum:
+
     https://mail.python.org/pipermail/edu-sig/2007-February/007787.html
 
 Customizing behavior
@@ -54,37 +57,37 @@ function is called *instead* of performing the regular livepatch mechanism.
 
 The __livepatch__() function is called with the following arguments:
 
-  - C{old}         : The object to be updated with contents of C{new}
-  - C{new}         : The object whose contents to put into C{old}
-  - C{do_livepatch}: A function that can be called to do the standard
-                     livepatch, replacing the contents of C{old} with C{new}.
-                     If it's not possible to livepatch C{old}, it returns
-                     C{new}.  The C{do_livepatch} function takes no arguments.
-                     Calling the C{do_livepatch} function is roughly
-                     equivalent to calling C{pyflyby.livepatch(old, new,
-                     modname=modname, heed_hook=False)}.
-  - C{modname}     : The module currently being updated.  Recursively called
-                     updates should keep track of the module being updated to
-                     avoid touching other modules.
+  - ``old``         : The object to be updated with contents of ``new``
+  - ``new``         : The object whose contents to put into ``old``
+  - ``do_livepatch``: A function that can be called to do the standard
+                      livepatch, replacing the contents of ``old`` with ``new``.
+                      If it's not possible to livepatch ``old``, it returns
+                      ``new``.  The ``do_livepatch`` function takes no arguments.
+                      Calling the ``do_livepatch`` function is roughly
+                      equivalent to calling ``pyflyby.livepatch(old, new,
+                      modname=modname, heed_hook=False)``.
+  - ``modname``     : The module currently being updated.  Recursively called
+                      updates should keep track of the module being updated to
+                      avoid touching other modules.
 
 These arguments are matched by *name* and are passed only if the
-C{__livepatch__} function is declared to take such named arguments or it takes
-**kwargs.  If the C{__livepatch__} function takes **kwargs, it should ignore
+``__livepatch__`` function is declared to take such named arguments or it takes
+**kwargs.  If the ``__livepatch__`` function takes **kwargs, it should ignore
 unknown arguments, in case new parameters are added in the future.
 
-If the object being updated is an object instance, and C{__livepatch__} is a
-method, then the function is bound to the new object, i.e. the C{self}
-parameter is the same as C{new}.
+If the object being updated is an object instance, and ``__livepatch__`` is a
+method, then the function is bound to the new object, i.e. the ``self``
+parameter is the same as ``new``.
 
-If the C{__livepatch__} function successfully patched the C{old} object, then
-it should return C{old}.  If it is unable to patch, it should return C{new}.
+If the ``__livepatch__`` function successfully patched the ``old`` object, then
+it should return ``old``.  If it is unable to patch, it should return ``new``.
 
 Examples
 --------
 
 By default, any attributes on an existing function are updated with ones from
 the new function.  If you want a memoized function to keep its cache across
-xreload, you could implement that like this:
+xreload, you could implement that like this::
 
   def memoize(function):
       cache = {}
@@ -165,34 +168,34 @@ def livepatch(old, new, modname=None,
               visit_stack=(), cache=None, assume_type=None,
               heed_hook=True):
     """
-    Livepatch C{old} with contents of C{new}.
+    Livepatch ``old`` with contents of ``new``.
 
-    If C{old} can't be livepatched, then return C{new}.
+    If ``old`` can't be livepatched, then return ``new``.
 
-    @param old:
+    :param old:
       The object to be updated
-    @param new:
+    :param new:
       The object used as the source for the update.
-    @type modname:
-      C{str}
-    @param modname:
-      Only livepatch C{old} if it was defined in the given fully-qualified
-      module name.  If C{None}, then update regardless of module.
-    @param assume_type:
-      Update as if both C{old} and C{new} were of type C{assume_type}.  If
-      C{None}, then C{old} and C{new} must have the same type.
+    :type modname:
+      ``str``
+    :param modname:
+      Only livepatch ``old`` if it was defined in the given fully-qualified
+      module name.  If ``None``, then update regardless of module.
+    :param assume_type:
+      Update as if both ``old`` and ``new`` were of type ``assume_type``.  If
+      ``None``, then ``old`` and ``new`` must have the same type.
       For internal use.
-    @param cache:
+    :param cache:
       Cache of already-updated objects.  Map from (id(old), id(new)) to result.
-    @param visit_stack:
+    :param visit_stack:
       Ids of objects that are currently being updated.
       Used to deal with reference cycles.
       For internal use.
-    @param heed_hook:
-      If C{True}, heed the C{__livepatch__} hook on C{new}, if any.
-      If C{False}, ignore any C{__livepatch__} hook on C{new}.
-    @return:
-      Either live-patched C{old}, or C{new}.
+    :param heed_hook:
+      If ``True``, heed the ``__livepatch__`` hook on ``new``, if any.
+      If ``False``, ignore any ``__livepatch__`` hook on ``new``.
+    :return:
+      Either live-patched ``old``, or ``new``.
     """
     if old is new:
         return new
@@ -241,7 +244,7 @@ def livepatch(old, new, modname=None,
             mro = [use_type, object] # old-style class
         # Dispatch on type.  Include parent classes (in C3 linearized
         # method resolution order), in particular so that this works on
-        # classes with custom metaclasses that subclass C{type}.
+        # classes with custom metaclasses that subclass ``type``.
         for t in mro:
             try:
                 update = _LIVEPATCH_DISPATCH_TABLE[t]
@@ -249,7 +252,7 @@ def livepatch(old, new, modname=None,
             except KeyError:
                 pass
         else:
-            # We should have found at least C{object}
+            # We should have found at least ``object``
             raise AssertionError("unreachable")
         # Dispatch.
         return update(old, new, modname=modname,
@@ -411,6 +414,7 @@ def _livepatch__method(old_method, new_method, modname, cache, visit_stack):
 def _livepatch__setattr(oldobj, newobj, name, modname, cache, visit_stack):
     """
     Livepatch something via setattr, i.e.::
+
        oldobj.{name} = livepatch(oldobj.{name}, newobj.{name}, ...)
     """
     newval = getattr(newobj, name)
@@ -490,7 +494,7 @@ def _livepatch__object(oldobj, newobj, modname, cache, visit_stack):
     """
     Livepatch a general object.
     """
-    # It's not obvious whether C{oldobj} and C{newobj} are actually supposed
+    # It's not obvious whether ``oldobj`` and ``newobj`` are actually supposed
     # to represent the same object.  For now, we take a middle ground of
     # livepatching iff the class was also defined in the same module.  In that
     # case at least we know that the object was defined in this module and
@@ -546,18 +550,18 @@ elif six.PY3:
 
 def _get_definition_module(obj):
     """
-    Get the name of the module that an object is defined in, or C{None} if
+    Get the name of the module that an object is defined in, or ``None`` if
     unknown.
 
-    For classes and functions, this returns the C{__module__} attribute.
+    For classes and functions, this returns the ``__module__`` attribute.
 
-    For object instances, this returns C{None}, ignoring the C{__module__}
-    attribute.  The reason is that the C{__module__} attribute on an instance
+    For object instances, this returns ``None``, ignoring the ``__module__``
+    attribute.  The reason is that the ``__module__`` attribute on an instance
     just gives the module that the class was defined in, which is not
     necessarily the module where the instance was constructed.
 
-    @rtype:
-      C{str}
+    :rtype:
+      ``str``
     """
     if isinstance(obj, (type, six.class_types, types.FunctionType,
                         types.MethodType)):
@@ -633,13 +637,13 @@ def _xreload_module(module, filename, force=False):
     """
     Reload a module in place, using livepatch.
 
-    @type module:
-      C{ModuleType}
-    @param module:
+    :type module:
+      ``ModuleType``
+    :param module:
       Module to reload.
-    @param force:
+    :param force:
       Whether to reload even if the module has not been modified since the
-      previous load.  If C{False}, then do nothing.  If C{True}, then reload.
+      previous load.  If ``False``, then do nothing.  If ``True``, then reload.
     """
     import linecache
     if not filename or not filename.endswith(".py"):
@@ -706,17 +710,17 @@ def _xreload_module(module, filename, force=False):
         # Temporarily put the temporary module in sys.modules, in case the
         # code references sys.modules[__name__] for some reason.  Normally on
         # success, we will revert this what that was there before (which
-        # normally should be C{module}).  If an error occurs, we'll also
+        # normally should be ``module``).  If an error occurs, we'll also
         # revert.  If the user has defined a __livepatch__ hook at the module
         # level, it's possible for result to not be the old module.
         sys.modules[module.__name__] = new_mod
         # *** Execute new code ***
         exec(code, new_mod.__dict__)
-        # Normally C{module} is of type C{ModuleType}.  However, in some
+        # Normally ``module`` is of type ``ModuleType``.  However, in some
         # cases, the module might have done a "proxy module" trick where the
         # module is replaced by a proxy object of some other type.  Regardless
-        # of the actual type, we do the update as C{module} were of type
-        # C{ModuleType}.
+        # of the actual type, we do the update as ``module`` were of type
+        # ``ModuleType``.
         assume_type = types.ModuleType
         # Livepatch the module.
         result = livepatch(module, new_mod, module.__name__,
@@ -760,22 +764,24 @@ def xreload(*args):
     module.
 
     For example, suppose m1.py contains::
+
       from m2 import foo
       def print_foo():
           return foo()
 
     and m2.py contains::
+
       def foo():
           return 42
 
-    If you edit m2.py and modify C{foo}, then reload(m2) on its own would not
+    If you edit m2.py and modify ``foo``, then reload(m2) on its own would not
     do what you want.  The built-in reload affects the module being reloaded,
     but references to the old module remain.  On the other hand, xreload()
     patches the existing m2.foo, so that live references to it are updated.
 
-    @type args:
-      C{str}s and/or C{ModuleType}s
-    @param args:
+    :type args:
+      ``str`` s and/or ``ModuleType`` s
+    :param args:
       Module(s) to reload.  If no argument is specified, then reload all
       recently modified modules.
     """

--- a/lib/python/pyflyby/_log.py
+++ b/lib/python/pyflyby/_log.py
@@ -61,19 +61,19 @@ class _PyflybyHandler(Handler):
     def HookCtx(self, pre, post):
         """
         Enter a context where:
-          * C{pre} is called before the first time a log record is emitted
+          * ``pre`` is called before the first time a log record is emitted
             during the context, and
-          * C{post} is called at the end of the context, if any log records
+          * ``post`` is called at the end of the context, if any log records
             were emitted during the context.
 
-        @type pre:
-          C{callable}
-        @param pre:
+        :type pre:
+          ``callable``
+        :param pre:
           Function to call before the first time something is logged during
           this context.
-        @type post:
-          C{callable}
-        @param post:
+        :type post:
+          ``callable``
+        :param post:
           Function to call before returning from the context, if anything was
           logged during the context.
         """
@@ -161,10 +161,11 @@ def _PromptToolkitStdoutProxyRawCtx(proxy):
 @contextmanager
 def _NoRegisterLoggerHandlerInHandlerListCtx():
     """
-    Work around a bug in the C{logging} module for Python 2.x-3.2.
+    Work around a bug in the ``logging`` module for Python 2.x-3.2.
 
-    The Python stdlib C{logging} module has a bug where you sometimes get the
+    The Python stdlib ``logging`` module has a bug where you sometimes get the
     following warning at exit::
+
       Exception TypeError: "'NoneType' object is not callable" in <function
       _removeHandlerRef at 0x10a1b3f50> ignored
 
@@ -179,8 +180,8 @@ def _NoRegisterLoggerHandlerInHandlerListCtx():
     was a no-op anyway, and even if we needed it, we could call it ourselves
     atexit.
 
-    @see:
-      U{http://bugs.python.org/issue9501}
+    :see:
+      http://bugs.python.org/issue9501
     """
     if not hasattr(logging, "_handlerList"):
         yield
@@ -210,10 +211,10 @@ class PyflybyLogger(Logger):
 
     def set_level(self, level):
         """
-        Set the pyflyby logger's level to C{level}.
+        Set the pyflyby logger's level to ``level``.
 
-        @type level:
-          C{str}
+        :type level:
+          ``str``
         """
         if isinstance(level, int):
             level_num = level

--- a/lib/python/pyflyby/_modules.py
+++ b/lib/python/pyflyby/_modules.py
@@ -178,12 +178,12 @@ class ModuleHandle(object):
         """
         Return the module instance.
 
-        @rtype:
-          C{types.ModuleType}
-        @raise ErrorDuringImportError:
+        :rtype:
+          ``types.ModuleType``
+        :raise ErrorDuringImportError:
           The module should exist but an error occurred while attempting to
           import it.
-        @raise ImportError:
+        :raise ImportError:
           The module doesn't exist.
         """
         # First check if prefix component is importable.
@@ -223,8 +223,8 @@ class ModuleHandle(object):
         top-level module/package, accessing this attribute may cause the
         parent package to be imported.
 
-        @rtype:
-          L{Filename}
+        :rtype:
+          `Filename`
         """
         # Use the loader mechanism to find the filename.  We do so instead of
         # using self.module.__file__, because the latter forces importing a
@@ -262,8 +262,8 @@ class ModuleHandle(object):
         """
         Enumerate all top-level packages/modules.
 
-        @rtype:
-          C{tuple} of L{ModuleHandle}s
+        :rtype:
+          ``tuple`` of `ModuleHandle` s
         """
         import pkgutil
         # Get the list of top-level packages/modules using pkgutil.
@@ -293,8 +293,8 @@ class ModuleHandle(object):
           >>> ModuleHandle("email").submodules      # doctest:+ELLIPSIS
           (..., 'email.encoders', ..., 'email.mime', ...)
 
-        @rtype:
-          C{tuple} of L{ModuleHandle}s
+        :rtype:
+          ``tuple`` of `ModuleHandle` s
         """
         import pkgutil
         module = self.module
@@ -302,7 +302,7 @@ class ModuleHandle(object):
             path = module.__path__
         except AttributeError:
             return ()
-        # Enumerate the modules at a given path.  Prefer to use C{pkgutil} if
+        # Enumerate the modules at a given path.  Prefer to use ``pkgutil`` if
         # we can.  However, if it fails due to OSError, use our own version
         # which is robust to that.
         try:
@@ -320,10 +320,10 @@ class ModuleHandle(object):
         Note that this requires involves actually importing this module, which
         may have side effects.  (TODO: rewrite to avoid this?)
 
-        @rtype:
-          L{ImportSet} or C{None}
-        @return:
-          Exports, or C{None} if nothing exported.
+        :rtype:
+          `ImportSet` or ``None``
+        :return:
+          Exports, or ``None`` if nothing exported.
         """
         from pyflyby._importclns import ImportStatement, ImportSet
         module = self.module
@@ -395,14 +395,14 @@ class ModuleHandle(object):
     @classmethod
     def containing(cls, identifier):
         """
-        Try to find the module that defines a name such as C{a.b.c} by trying
-        to import C{a}, C{a.b}, and C{a.b.c}.
+        Try to find the module that defines a name such as ``a.b.c`` by trying
+        to import ``a``, ``a.b``, and ``a.b.c``.
 
-        @return:
-          The name of the 'deepest' module (most commonly it would be C{a.b}
+        :return:
+          The name of the 'deepest' module (most commonly it would be ``a.b``
           in this example).
-        @rtype:
-          L{Module}
+        :rtype:
+          `Module`
         """
         # In the code below we catch "Exception" rather than just ImportError
         # or AttributeError since importing and __getattr__ing can raise other

--- a/lib/python/pyflyby/_parse.py
+++ b/lib/python/pyflyby/_parse.py
@@ -66,14 +66,14 @@ def _flatten_ast_nodes(arg):
 
 def _iter_child_nodes_in_order(node):
     """
-    Yield all direct child nodes of C{node}, that is, all fields that are nodes
+    Yield all direct child nodes of ``node``, that is, all fields that are nodes
     and all items of fields that are lists of nodes.
 
-    C{_iter_child_nodes_in_order} yields nodes in the same order that they
+    ``_iter_child_nodes_in_order`` yields nodes in the same order that they
     appear in the source.
 
-    C{ast.iter_child_nodes} does the same thing, but not in source order.
-    e.g. for C{Dict}s, it yields all key nodes before all value nodes.
+    ``ast.iter_child_nodes`` does the same thing, but not in source order.
+    e.g. for ``Dict`` s, it yields all key nodes before all value nodes.
     """
     return _flatten_ast_nodes(_iter_child_nodes_in_order_internal_1(node))
 
@@ -118,15 +118,15 @@ def _iter_child_nodes_in_order_internal_1(node):
 
 def _walk_ast_nodes_in_order(node):
     """
-    Recursively yield all child nodes of C{node}, in the same order that the
+    Recursively yield all child nodes of ``node``, in the same order that the
     node appears in the source.
 
-    C{ast.walk} does the same thing, but yields nodes in an arbitrary order.
+    ``ast.walk`` does the same thing, but yields nodes in an arbitrary order.
     """
-    # The implementation is basically the same as C{ast.walk}, but:
+    # The implementation is basically the same as ``ast.walk``, but:
     #   1. Use a stack instead of a deque.  (I.e., depth-first search instead
     #      of breadth-first search.)
-    #   2. Use _iter_child_nodes_in_order instead of C{ast.iter_child_nodes}.
+    #   2. Use _iter_child_nodes_in_order instead of ``ast.iter_child_nodes``.
     todo = [node]
     while todo:
         node = todo.pop()
@@ -136,10 +136,10 @@ def _walk_ast_nodes_in_order(node):
 
 def _flags_to_try(source, flags, auto_flags, mode):
     """
-    Flags to try for C{auto_flags}.
+    Flags to try for ``auto_flags``.
 
-    If C{auto_flags} is False, then only yield C{flags}.
-    If C{auto_flags} is True, then yield C{flags} and C{flags ^ print_function}.
+    If ``auto_flags`` is False, then only yield ``flags``.
+    If ``auto_flags`` is True, then yield ``flags`` and ``flags ^ print_function``.
     """
     flags = CompilerFlags(flags)
     if not auto_flags:
@@ -162,22 +162,22 @@ def _parse_ast_nodes(text, flags, auto_flags, mode):
     """
     Parse a block of lines into an AST.
 
-    Also annotate C{input_flags}, C{source_flags}, and C{flags} on the
+    Also annotate ``input_flags``, ``source_flags``, and ``flags`` on the
     resulting ast node.
 
-    @type text:
-      C{FileText}
-    @type flags:
-      C{CompilerFlags}
-    @type auto_flags:
-      C{bool}
-    @param auto_flags:
-      Whether to guess different flags if C{text} can't be parsed with
-      C{flags}.
-    @param mode:
+    :type text:
+      ``FileText``
+    :type flags:
+      ``CompilerFlags``
+    :type auto_flags:
+      ``bool``
+    :param auto_flags:
+      Whether to guess different flags if ``text`` can't be parsed with
+      ``flags``.
+    :param mode:
       Compilation mode: "exec", "single", or "eval".
-    @rtype:
-      C{ast.Module}
+    :rtype:
+      ``ast.Module``
     """
     text = FileText(text)
     flags = CompilerFlags(flags)
@@ -187,7 +187,7 @@ def _parse_ast_nodes(text, flags, auto_flags, mode):
     if PY2 and isinstance(source, unicode):
         source = source.encode('utf-8')
     if not source.endswith("\n"):
-        # Ensure that the last line ends with a newline (C{ast} barfs
+        # Ensure that the last line ends with a newline (``ast`` barfs
         # otherwise).
         source += "\n"
     exp = None
@@ -211,8 +211,8 @@ def _parse_ast_nodes(text, flags, auto_flags, mode):
 
 def _test_parse_string_literal(text, flags):
     r"""
-    Attempt to parse C{text}.  If it parses cleanly to a single string
-    literal, return its value.  Otherwise return C{None}.
+    Attempt to parse ``text``.  If it parses cleanly to a single string
+    literal, return its value.  Otherwise return ``None``.
 
       >>> _test_parse_string_literal(r'"foo\n" r"\nbar"', 0)
       'foo\n\\nbar'
@@ -235,14 +235,14 @@ def _annotate_ast_nodes(ast_node):
     """
     Annotate AST with:
       - startpos and endpos
-      - [disabled for now: context as L{AstNodeContext}]
+      - [disabled for now: context as `AstNodeContext` ]
 
-    @type ast_node:
-      C{ast.AST}
-    @param ast_node:
-      AST node returned by L{_parse_ast_nodes}
-    @return:
-      C{None}
+    :type ast_node:
+      ``ast.AST``
+    :param ast_node:
+      AST node returned by `_parse_ast_nodes`
+    :return:
+      ``None``
     """
     text = ast_node.text
     flags = ast_node.flags
@@ -255,50 +255,50 @@ def _annotate_ast_nodes(ast_node):
 
 def _annotate_ast_startpos(ast_node, parent_ast_node, minpos, text, flags):
     """
-    Annotate C{ast_node}.  Set C{ast_node.startpos} to the starting position
-    of the node within C{text}.
+    Annotate ``ast_node``.  Set ``ast_node.startpos`` to the starting position
+    of the node within ``text``.
 
     For "typical" nodes, i.e. those other than multiline strings, this is
     simply FilePos(ast_node.lineno, ast_node.col_offset+1), but taking
-    C{text.startpos} into account.
+    ``text.startpos`` into account.
 
     For multiline string nodes, this function works by trying to parse all
     possible subranges of lines until finding the range that is syntactically
-    valid and matches C{value}.  The candidate range is
+    valid and matches ``value``.  The candidate range is
     text[min_start_lineno:lineno+text.startpos.lineno+1].
 
     This function is unfortunately necessary because of a flaw in the output
     produced by the Python built-in parser.  For some crazy reason, the
-    C{ast_node.lineno} attribute represents something different for multiline
+    ``ast_node.lineno`` attribute represents something different for multiline
     string literals versus all other statements.  For multiline string literal
     nodes and statements that are just a string expression (or more generally,
     nodes where the first descendant leaf node is a multiline string literal),
-    the compiler attaches the ending line number as the value of the C{lineno}
+    the compiler attaches the ending line number as the value of the ``lineno``
     attribute.  For all other than AST nodes, the compiler attaches the
-    starting line number as the value of the C{lineno} attribute.  This means
+    starting line number as the value of the ``lineno`` attribute.  This means
     e.g. the statement "'''foo\nbar'''" has a lineno value of 2, but the
     statement "x='''foo\nbar'''" has a lineno value of 1.
 
-    @type ast_node:
-      C{ast.AST}
-    @type minpos:
-      L{FilePos}
-    @param minpos:
-      Earliest position to check, in the number space of C{text}.
-    @type text:
-      L{FileText}
-    @param text:
-      Source text that was used to parse the AST, whose C{startpos} should be
-      used in interpreting C{ast_node.lineno} (which always starts at 1 for
+    :type ast_node:
+      ``ast.AST``
+    :type minpos:
+      `FilePos`
+    :param minpos:
+      Earliest position to check, in the number space of ``text``.
+    :type text:
+      `FileText`
+    :param text:
+      Source text that was used to parse the AST, whose ``startpos`` should be
+      used in interpreting ``ast_node.lineno`` (which always starts at 1 for
       the subset that was parsed).
-    @type flags:
-      C{CompilerFlags}
-    @param flags:
+    :type flags:
+      ``CompilerFlags``
+    :param flags:
       Compiler flags to use when re-compiling code.
-    @return:
-      C{True} if this node is a multiline string literal or the first child is
-      such a node (recursively); C{False} otherwise.
-    @raise ValueError:
+    :return:
+      ``True`` if this node is a multiline string literal or the first child is
+      such a node (recursively); ``False`` otherwise.
+    :raise ValueError:
       Could not find the starting line number.
     """
     # First, traverse child nodes.  If the first child node (recursively) is a
@@ -337,7 +337,7 @@ def _annotate_ast_startpos(ast_node, parent_ast_node, minpos, text, flags):
             child_minpos = child_node.startpos
         is_first_child = False
     # If the node has no lineno at all, then skip it.  This should only happen
-    # for nodes we don't care about, e.g. C{ast.Module} or C{ast.alias}.
+    # for nodes we don't care about, e.g. ``ast.Module`` or ``ast.alias``.
     if not hasattr(ast_node, 'lineno'):
         return False
     # If col_offset is set then the lineno should be correct also.
@@ -385,12 +385,12 @@ def _annotate_ast_startpos(ast_node, parent_ast_node, minpos, text, flags):
         # multiline string.  The bug that multiline strings have broken
         # lineno/col_offset infects ancestors up the tree.
         #
-        # If the leftmost leaf is a multi-line string, then C{lineno}
+        # If the leftmost leaf is a multi-line string, then ``lineno``
         # contains the ending line number, and col_offset is -1:
         #   >>> ast.parse("""'''foo\nbar'''+blah""").body[0].lineno
         #   2
         # But if the leftmost leaf is not a multi-line string, then
-        # C{lineno} contains the starting line number:
+        # ``lineno`` contains the starting line number:
         #   >>> ast.parse("""'''foobar'''+blah""").body[0].lineno
         #   1
         #   >>> ast.parse("""blah+'''foo\nbar'''+blah""").body[0].lineno
@@ -408,15 +408,15 @@ def _annotate_ast_startpos(ast_node, parent_ast_node, minpos, text, flags):
     if not isinstance(ast_node, (ast.Str, Bytes)):
         raise ValueError(
             "got a non-string col_offset=-1: %s" % (ast.dump(ast_node)))
-    # The C{lineno} attribute gives the ending line number of the multiline
+    # The ``lineno`` attribute gives the ending line number of the multiline
     # string ... unless it's multiple multiline strings that are concatenated
     # by adjacency, in which case it's merely the end of the first one of
     # them.  At least we know that the start lineno is definitely not later
-    # than the C{lineno} attribute.
+    # than the ``lineno`` attribute.
     first_end_lineno = text.startpos.lineno + ast_node.lineno - 1
     # Compute possible start positions.
     # The starting line number of this string could be anywhere between the
-    # end of the previous expression and C{first_end_lineno}.
+    # end of the previous expression and ``first_end_lineno``.
     startpos_candidates = []
     assert minpos.lineno <= first_end_lineno
     for start_lineno in range(minpos.lineno, first_end_lineno + 1):
@@ -513,12 +513,12 @@ def _annotate_ast_startpos(ast_node, parent_ast_node, minpos, text, flags):
 
 def _annotate_ast_context(ast_node):
     """
-    Recursively annotate C{context} on ast nodes, setting C{context} to
-    a L{AstNodeContext} named tuple with values
-    C{(parent, field, index)}.
-    Each ast_node satisfies C{parent.<field>[<index>] is ast_node}.
+    Recursively annotate ``context`` on ast nodes, setting ``context`` to
+    a `AstNodeContext` named tuple with values
+    ``(parent, field, index)``.
+    Each ast_node satisfies ``parent.<field>[<index>] is ast_node``.
 
-    For non-list fields, the index part is C{None}.
+    For non-list fields, the index part is ``None``.
     """
     for field_name, field_value in ast.iter_fields(ast_node):
         if isinstance(field_value, ast.AST):
@@ -535,19 +535,19 @@ def _annotate_ast_context(ast_node):
 
 def _split_code_lines(ast_nodes, text):
     """
-    Split the given C{ast_nodes} and corresponding C{text} by code/noncode
+    Split the given ``ast_nodes`` and corresponding ``text`` by code/noncode
     statement.
 
-    Yield tuples of (nodes, subtext).  C{nodes} is a list of C{ast.AST} nodes,
-    length 0 or 1; C{subtext} is a L{FileText} sliced from C{text}.
+    Yield tuples of (nodes, subtext).  ``nodes`` is a list of ``ast.AST`` nodes,
+    length 0 or 1; ``subtext`` is a `FileText` sliced from ``text``.
 
-    FileText(...))} for code lines and C{(None, FileText(...))} for non-code
+    FileText(...))} for code lines and ``(None, FileText(...))`` for non-code
     lines (comments and blanks).
 
-    @type ast_nodes:
-      sequence of C{ast.AST} nodes
-    @type text:
-      L{FileText}
+    :type ast_nodes:
+      sequence of ``ast.AST`` nodes
+    :type text:
+      `FileText`
     """
     if not ast_nodes:
         yield ([], text)
@@ -618,24 +618,25 @@ def _split_code_lines(ast_nodes, text):
 
 def _ast_node_is_in_docstring_position(ast_node):
     """
-    Given a C{Str} AST node, return whether its position within the AST makes
+    Given a ``Str`` AST node, return whether its position within the AST makes
     it eligible as a docstring.
 
-    The main way a C{Str} can be a docstring is if it is a standalone string
-    at the beginning of a C{Module}, C{FunctionDef}, or C{ClassDef}.
+    The main way a ``Str`` can be a docstring is if it is a standalone string
+    at the beginning of a ``Module``, ``FunctionDef``, or ``ClassDef``.
 
     We also support variable docstrings per Epydoc:
+
       - If a variable assignment statement is immediately followed by a bare
         string literal, then that assignment is treated as a docstring for
         that variable.
 
-    @type ast_node:
-      C{ast.Str}
-    @param ast_node:
-      AST node that has been annotated by C{_annotate_ast_nodes}.
-    @rtype:
-      C{bool}
-    @return:
+    :type ast_node:
+      ``ast.Str``
+    :param ast_node:
+      AST node that has been annotated by ``_annotate_ast_nodes``.
+    :rtype:
+      ``bool``
+    :return:
       Whether this string ast node is in docstring position.
     """
     if not isinstance(ast_node, (ast.Str, Bytes)):
@@ -661,12 +662,12 @@ def _ast_node_is_in_docstring_position(ast_node):
 
 def infer_compile_mode(arg):
     """
-    Infer the mode needed to compile C{arg}.
+    Infer the mode needed to compile ``arg``.
 
-    @type arg:
-      C{ast.AST}
-    @rtype:
-      C{str}
+    :type arg:
+      ``ast.AST``
+    :rtype:
+      ``str``
     """
     # Infer mode from ast object.
     if isinstance(arg, ast.Module):
@@ -694,7 +695,7 @@ class PythonStatement(object):
       >>> PythonStatement('print("x",\n file=None)\n', flags=0x10000)
       PythonStatement('print("x",\n file=None)\n', flags=0x10000)
 
-    Implemented as a wrapper around a L{PythonBlock} containing at most one
+    Implemented as a wrapper around a `PythonBlock` containing at most one
     top-level AST node.
     """
 
@@ -728,43 +729,43 @@ class PythonStatement(object):
     @property
     def text(self):
         """
-        @rtype:
-          L{FileText}
+        :rtype:
+          `FileText`
         """
         return self.block.text
 
     @property
     def filename(self):
         """
-        @rtype:
-          L{Filename}
+        :rtype:
+          `Filename`
         """
         return self.text.filename
 
     @property
     def startpos(self):
         """
-        @rtype:
-          L{FilePos}
+        :rtype:
+          `FilePos`
         """
         return self.text.startpos
 
     @property
     def flags(self):
         """
-        @rtype:
-          L{CompilerFlags}
+        :rtype:
+          `CompilerFlags`
         """
         return self.block.flags
 
     @property
     def ast_node(self):
         """
-        A single AST node representing this statement, or C{None} if this
+        A single AST node representing this statement, or ``None`` if this
         object only represents comments/blanks.
 
-        @rtype:
-          C{ast.AST} or C{NoneType}
+        :rtype:
+          ``ast.AST`` or ``NoneType``
         """
         ast_nodes = self.block.ast_node.body
         if len(ast_nodes) == 0:
@@ -798,7 +799,7 @@ class PythonStatement(object):
           >>> PythonStatement('foo = {1: {2: 3}}').get_assignment_literal_value()
           ('foo', {1: {2: 3}})
 
-        @return:
+        :return:
           (target, literal_value)
         """
         if not self.is_single_assign:
@@ -846,7 +847,7 @@ class PythonStatement(object):
 class PythonBlock(object):
     r"""
     Representation of a sequence of consecutive top-level
-    L{PythonStatement}(s).
+    `PythonStatement` (s).
 
       >>> source_code = '# 1\nprint(2)\n# 3\n# 4\nprint(5)\nx=[6,\n 7]\n# 8\n'
       >>> codeblock = PythonBlock(source_code)
@@ -859,7 +860,7 @@ class PythonBlock(object):
       PythonStatement('x=[6,\n 7]\n', startpos=(6,1))
       PythonStatement('# 8\n', startpos=(8,1))
 
-    A C{PythonBlock} has a C{flags} attribute that gives the compiler_flags
+    A ``PythonBlock`` has a ``flags`` attribute that gives the compiler_flags
     associated with the __future__ features using which the code should be
     parsed.
 
@@ -891,24 +892,24 @@ class PythonBlock(object):
     def from_text(cls, text, filename=None, startpos=None, flags=None,
                   auto_flags=False):
         """
-        @type text:
-          L{FileText} or convertible
-        @type filename:
-          C{Filename}
-        @param filename:
-          Filename, if not already given by C{text}.
-        @type startpos:
-          C{FilePos}
-        @param startpos:
-          Starting position, if not already given by C{text}.
-        @type flags:
-          C{CompilerFlags}
-        @param flags:
+        :type text:
+          `FileText` or convertible
+        :type filename:
+          ``Filename``
+        :param filename:
+          Filename, if not already given by ``text``.
+        :type startpos:
+          ``FilePos``
+        :param startpos:
+          Starting position, if not already given by ``text``.
+        :type flags:
+          ``CompilerFlags``
+        :param flags:
           Input compiler flags.
-        @param auto_flags:
-          Whether to try other flags if C{flags} fails.
-        @rtype:
-          L{PythonBlock}
+        :param auto_flags:
+          Whether to try other flags if ``flags`` fails.
+        :rtype:
+          `PythonBlock`
         """
         text = FileText(text, filename=filename, startpos=startpos)
         self = object.__new__(cls)
@@ -940,9 +941,9 @@ class PythonBlock(object):
         """
         Concatenate a bunch of blocks into one block.
 
-        @type blocks:
-          sequence of L{PythonBlock}s and/or L{PythonStatement}s
-        @param assume_contiguous:
+        :type blocks:
+          sequence of `PythonBlock` s and/or `PythonStatement` s
+        :param assume_contiguous:
           Whether to assume, without checking, that the input blocks were
           originally all contiguous.  This must be set to True to indicate the
           caller understands the assumption; False is not implemented.
@@ -954,7 +955,7 @@ class PythonBlock(object):
             return blocks[0]
         assert blocks
         text = FileText.concatenate([b.text for b in blocks])
-        # The contiguous assumption is important here because C{ast_node}
+        # The contiguous assumption is important here because ``ast_node``
         # contains line information that would otherwise be wrong.
         ast_nodes = [n for b in blocks for n in b.annotated_ast_node.body]
         flags = blocks[0].flags
@@ -978,7 +979,7 @@ class PythonBlock(object):
         Attempt to parse this block of code into an abstract syntax tree.
         Cached (including exception case).
 
-        @return:
+        :return:
           Either ast_node or exception.
         """
         # This attribute may also be set by __construct_from_annotated_ast(),
@@ -1000,22 +1001,22 @@ class PythonBlock(object):
     @cached_attribute
     def parsable(self):
         """
-        Whether the contents of this C{PythonBlock} are parsable as Python
+        Whether the contents of this ``PythonBlock`` are parsable as Python
         code, using the given flags.
 
-        @rtype:
-          C{bool}
+        :rtype:
+          ``bool``
         """
         return isinstance(self._ast_node_or_parse_exception, ast.AST)
 
     @cached_attribute
     def parsable_as_expression(self):
         """
-        Whether the contents of this C{PythonBlock} are parsable as a single
+        Whether the contents of this ``PythonBlock`` are parsable as a single
         Python expression, using the given flags.
 
-        @rtype:
-          C{bool}
+        :rtype:
+          ``bool``
         """
         return self.parsable and self.expression_ast_node is not None
 
@@ -1025,14 +1026,14 @@ class PythonBlock(object):
         Parse this block of code into an abstract syntax tree.
 
         The returned object type is the kind of AST as returned by the
-        C{compile} built-in (rather than as returned by the older, deprecated
-        C{compiler} module).  The code is parsed using mode="exec".
+        ``compile`` built-in (rather than as returned by the older, deprecated
+        ``compiler`` module).  The code is parsed using mode="exec".
 
-        The result is a C{ast.Module} node, even if this block represents only
+        The result is a ``ast.Module`` node, even if this block represents only
         a subset of the entire file.
 
-        @rtype:
-          C{ast.Module}
+        :rtype:
+          ``ast.Module``
         """
         r = self._ast_node_or_parse_exception
         if isinstance(r, ast.AST):
@@ -1043,13 +1044,13 @@ class PythonBlock(object):
     @cached_attribute
     def annotated_ast_node(self):
         """
-        Return C{self.ast_node}, annotated in place with positions.
+        Return ``self.ast_node``, annotated in place with positions.
 
-        All nodes are annotated with C{startpos}.
-        All top-level nodes are annotated with C{endpos}.
+        All nodes are annotated with ``startpos``.
+        All top-level nodes are annotated with ``endpos``.
 
-        @rtype:
-          C{ast.Module}
+        :rtype:
+          ``ast.Module``
         """
         result = self.ast_node
         _annotate_ast_nodes(result)
@@ -1058,13 +1059,13 @@ class PythonBlock(object):
     @cached_attribute
     def expression_ast_node(self):
         """
-        Return an C{ast.Expression} if C{self.ast_node} can be converted into
+        Return an ``ast.Expression`` if ``self.ast_node`` can be converted into
         one.  I.e., return parse(self.text, mode="eval"), if possible.
 
-        Otherwise, return C{None}.
+        Otherwise, return ``None``.
 
-        @rtype:
-          C{ast.Expression}
+        :rtype:
+          ``ast.Expression``
         """
         node = self.ast_node
         if len(node.body) == 1 and isinstance(node.body[0], ast.Expr):
@@ -1076,13 +1077,13 @@ class PythonBlock(object):
         """
         Parse the source text into an AST.
 
-        @param mode:
+        :param mode:
           Compilation mode: "exec", "single", or "eval".  "exec", "single",
-          and "eval" work as the built-in C{compile} function do.  If C{None},
+          and "eval" work as the built-in ``compile`` function do.  If ``None``,
           then default to "eval" if the input is a string with a single
           expression, else "exec".
-        @rtype:
-          C{ast.AST}
+        :rtype:
+          ``ast.AST``
         """
         if mode == "exec":
             return self.ast_node
@@ -1105,8 +1106,8 @@ class PythonBlock(object):
         """
         Parse into AST and compile AST into code.
 
-        @rtype:
-          C{CodeType}
+        :rtype:
+          ``CodeType``
         """
         ast_node = self.parse(mode=mode)
         mode = infer_compile_mode(ast_node)
@@ -1116,8 +1117,8 @@ class PythonBlock(object):
     @cached_attribute
     def statements(self):
         r"""
-        Partition of this C{PythonBlock} into individual C{PythonStatement}s.
-        Each one contains at most 1 top-level ast node.  A C{PythonStatement}
+        Partition of this ``PythonBlock`` into individual ``PythonStatement`` s.
+        Each one contains at most 1 top-level ast node.  A ``PythonStatement``
         can contain no ast node to represent comments.
 
           >>> code = "# multiline\n# comment\n'''multiline\nstring'''\nblah\n"
@@ -1126,8 +1127,8 @@ class PythonBlock(object):
            PythonStatement("'''multiline\nstring'''\n", startpos=(3,1)),
            PythonStatement('blah\n', startpos=(5,1)))
 
-        @rtype:
-          C{tuple} of L{PythonStatement}s
+        :rtype:
+          ``tuple`` of `PythonStatement` s
         """
         node = self.annotated_ast_node
         nodes_subtexts = list(_split_code_lines(node.body, self.text))
@@ -1144,7 +1145,7 @@ class PythonBlock(object):
         for b in statement_blocks:
             statement = PythonStatement._construct_from_block(b)
             statements.append(statement)
-            # Optimization: set the new sub-block's C{statements} attribute
+            # Optimization: set the new sub-block's ``statements`` attribute
             # since we already know it contains exactly one statement, itself.
             assert 'statements' not in b.__dict__
             b.statements = (statement,)
@@ -1156,13 +1157,13 @@ class PythonBlock(object):
         If the AST contains __future__ imports, then the compiler_flags
         associated with them.  Otherwise, 0.
 
-        The difference between C{source_flags} and C{flags} is that C{flags}
+        The difference between ``source_flags`` and ``flags`` is that ``flags``
         may be set by the caller (e.g. based on an earlier __future__ import)
-        and include automatically guessed flags, whereas C{source_flags} is
+        and include automatically guessed flags, whereas ``source_flags`` is
         only nonzero if this code itself contains __future__ imports.
 
-        @rtype:
-          L{CompilerFlags}
+        :rtype:
+          `CompilerFlags`
         """
         return self.ast_node.source_flags
 
@@ -1173,20 +1174,20 @@ class PythonBlock(object):
         (possibly automatically guessed), and the flags from "__future__"
         imports in the source code text.
 
-        @rtype:
-          L{CompilerFlags}
+        :rtype:
+          `CompilerFlags`
         """
         return self.ast_node.flags
 
     def groupby(self, predicate):
         """
         Partition this block of code into smaller blocks of code which
-        consecutively have the same C{predicate}.
+        consecutively have the same ``predicate``.
 
-        @param predicate:
-          Function that takes a L{PythonStatement} and returns a value.
-        @return:
-          Generator that yields (group, L{PythonBlock}s).
+        :param predicate:
+          Function that takes a `PythonStatement` and returns a value.
+        :return:
+          Generator that yields (group, `PythonBlock` s).
         """
         cls = type(self)
         for pred, stmts in groupby(self.statements, predicate):
@@ -1197,14 +1198,14 @@ class PythonBlock(object):
         r"""
         Yield all string literals anywhere in this block.
 
-        The string literals have C{startpos} attributes attached.
+        The string literals have ``startpos`` attributes attached.
 
           >>> block = PythonBlock("'a' + ('b' + \n'c')")
           >>> [(f.s, f.startpos) for f in block.string_literals()]
           [('a', FilePos(1,1)), ('b', FilePos(1,8)), ('c', FilePos(2,1))]
 
-        @return:
-          Iterable of C{ast.Str}  or C{ast.Bytes} nodes
+        :return:
+          Iterable of ``ast.Str``  or ``ast.Bytes`` nodes
         """
         for node in _walk_ast_nodes_in_order(self.annotated_ast_node):
             if isinstance(node, (ast.Str, Bytes)):
@@ -1215,15 +1216,16 @@ class PythonBlock(object):
         """
         Yield docstring AST nodes.
 
-        We consider the following to be docstrings:
+        We consider the following to be docstrings::
+
           - First literal string of function definitions, class definitions,
             and modules (the python standard)
           - Literal strings after assignments, per Epydoc
 
-        @rtype:
-          Generator of C{ast.Str} nodes
+        :rtype:
+          Generator of ``ast.Str`` nodes
         """
-        # This is similar to C{ast.get_docstring}, but:
+        # This is similar to ``ast.get_docstring``, but:
         #   - This function is recursive
         #   - This function yields the node object, rather than the string
         #   - This function yields multiple docstrings (even per ast node)
@@ -1260,8 +1262,8 @@ class PythonBlock(object):
           >>> PythonBlock("x\n'''\n >>> foo(bar\n ...     + baz)\n'''\n").get_doctests()
           [PythonBlock('foo(bar\n    + baz)\n', startpos=(3,2))]
 
-        @rtype:
-          C{list} of L{PythonStatement}s
+        :rtype:
+          ``list`` of `PythonStatement` s
         """
         import doctest
         parser = doctest.DocTestParser()

--- a/lib/python/pyflyby/_py.py
+++ b/lib/python/pyflyby/_py.py
@@ -116,42 +116,50 @@ Pseudo-actions valid before, after, or without code argument:
 Examples
 ========
 
-  Start IPython with pyflyby autoimporter enabled:
+  Start IPython with pyflyby autoimporter enabled::
+
     $ py
 
-  Start IPython/Jupyter Notebook with pyflyby autoimporter enabled:
+  Start IPython/Jupyter Notebook with pyflyby autoimporter enabled::
+
     $ py nb
 
-  Find the ASCII value of the letter "j" (apply builtin function):
+  Find the ASCII value of the letter "j" (apply builtin function)::
+
     $ py ord j
     [PYFLYBY] ord('j')
     106
 
-  Decode a base64-encoded string (apply autoimported function):
+  Decode a base64-encoded string (apply autoimported function)::
+
     $ py b64decode aGVsbG8=
     [PYFLYBY] from base64 import b64decode
     [PYFLYBY] b64decode('aGVsbG8=', altchars=None)
     b'hello'
 
-  Find the day of the week of some date (apply function in module):
+  Find the day of the week of some date (apply function in module)::
+
     $ py calendar.weekday 2014 7 18
     [PYFLYBY] import calendar
     [PYFLYBY] calendar.weekday(2014, 7, 18)
     4
 
-  Using named arguments:
+  Using named arguments::
+
     $ py calendar.weekday --day=16 --month=7 --year=2014
     [PYFLYBY] import calendar
     [PYFLYBY] calendar.weekday(2014, 7, 16)
     2
 
-  Using short named arguments:
+  Using short named arguments::
+
     $ py calendar.weekday -m 7 -d 15 -y 2014
     [PYFLYBY] import calendar
     [PYFLYBY] calendar.weekday(2014, 7, 15)
     1
 
-  Invert a matrix (evaluate expression, with autoimporting):
+  Invert a matrix (evaluate expression, with autoimporting)::
+
     $ py 'matrix("1 3 3; 1 4 3; 1 3 4").I'
     [PYFLYBY] from numpy import matrix
     [PYFLYBY] matrix("1 3 3; 1 4 3; 1 3 4").I
@@ -159,7 +167,8 @@ Examples
             [-1.,  1.,  0.],
             [-1.,  0.,  1.]])
 
-  Plot cosine (evaluate expression, with autoimporting):
+  Plot cosine (evaluate expression, with autoimporting)::
+
     $ py 'plot(cos(arange(30)))'
     [PYFLYBY] from numpy import arange
     [PYFLYBY] from numpy import cos
@@ -167,11 +176,13 @@ Examples
     [PYFLYBY] plot(cos(arange(30)))
     <plot>
 
-  Command-line calculator (multiple arguments):
+  Command-line calculator (multiple arguments)::
+
     $ py 3 / 4
     0.75
 
-  Command-line calculator (single arguments):
+  Command-line calculator (single arguments)::
+
     $ py '(5+7j) ** 12'
     (65602966976-150532462080j)
 
@@ -201,35 +212,43 @@ Examples
     [PYFLYBY] (lambda x: x**2)(5)
     25
 
-  Find length of string (using "-" for stdin):
+  Find length of string (using "-" for stdin)::
+
     $ echo hello | py len -
     [PYFLYBY] len('hello\\n')
     6
 
-  Run stdin as code:
+  Run stdin as code::
+
     $ echo 'print(sys.argv[1:])' | py - hello world
     [PYFLYBY] import sys
     ['hello', 'world']
 
-  Run libc functions:
+  Run libc functions::
+
     $ py --quiet --output=none 'CDLL("libc.so.6").printf' %03d 7
     007
 
-  Download web page:
+  Download web page::
+
     $ py --print 'requests.get(sys.argv[1]).text' http://example.com
 
-  Get function help:
+  Get function help::
+
     $ py b64decode?
     [PYFLYBY] from base64 import b64decode
-    Python signature:
+    Python signature::
+
       >> b64decode(s, altchars=None, validate=False)
 
-    Command-line signature:
+    Command-line signature::
+
       $ py b64decode s [altchars [validate]]
       $ py b64decode --s=... [--altchars=...] [--validate=...]
     ...
 
-  Get module help:
+  Get module help::
+
     $ py pandas?
     [PYFLYBY] import pandas
     Version:
@@ -403,10 +422,10 @@ def _requires_parens_as_function(function_name):
     TODO: this might be obsolete if we use unparse instead of keeping original
     user formatting (or alternatively, unparse should use something like this).
 
-    @type function_name:
-      C{str}
-    @rtype:
-      C{bool}
+    :type function_name:
+      ``str``
+    :rtype:
+      ``bool``
     """
     function_name = PythonBlock(function_name, flags=FLAGS)
     node = function_name.expression_ast_node
@@ -524,7 +543,8 @@ class UserExpr(object):
 
       >>> ns = _Namespace()
 
-    Heuristic auto-evaluation:
+    Heuristic auto-evaluation::
+
       >>> UserExpr('5+2', ns, "auto").value
       7
 
@@ -535,22 +555,26 @@ class UserExpr(object):
       [PYFLYBY] import base64
       b'Halloween'
 
-    Returning an unparsable argument as a string:
+    Returning an unparsable argument as a string::
+
       >>> UserExpr('Victory Loop', ns, "auto").value
       'Victory Loop'
 
-    Returning an undefined (and not auto-importable) argument as a string:
+    Returning an undefined (and not auto-importable) argument as a string::
+
       >>> UserExpr('Willowbrook29817621+5', ns, "auto").value
       'Willowbrook29817621+5'
 
-    Explicit literal string:
+    Explicit literal string::
+
       >>> UserExpr("2+3", ns, "raw_value").value
       '2+3'
 
       >>> UserExpr("'2+3'", ns, "raw_value").value
       "'2+3'"
 
-    Other raw values:
+    Other raw values::
+
       >>> UserExpr(sys.exit, ns, "raw_value").value
       <built-in function exit>
     """
@@ -559,18 +583,18 @@ class UserExpr(object):
         """
         Construct a new UserExpr.
 
-        @type arg:
-          C{str} if C{arg_mode} is "eval" or "auto"; anything if C{arg_mode}
+        :type arg:
+          ``str`` if ``arg_mode`` is "eval" or "auto"; anything if ``arg_mode``
           is "raw_value"
-        @param arg:
+        :param arg:
           Input user argument.
-        @type namespace:
-          L{_Namespace}
-        @type arg_mode:
-          C{str}
-        @param arg_mode:
-          If C{"raw_value"}, then return C{arg} unchanged.  If C{"eval"}, then
-          always evaluate C{arg}.  If C{"auto"}, then heuristically evaluate
+        :type namespace:
+          `_Namespace`
+        :type arg_mode:
+          ``str``
+        :param arg_mode:
+          If ``"raw_value"``, then return ``arg`` unchanged.  If ``"eval"``, then
+          always evaluate ``arg``.  If ``"auto"``, then heuristically evaluate
           if appropriate.
         """
         if arg_mode == "string":
@@ -653,8 +677,8 @@ def _parse_auto_apply_args(argspec, commandline_args, namespace, arg_mode="auto"
     Parse command-line arguments heuristically.  Arguments that can be
     evaluated are evaluated; otherwise they are treated as strings.
 
-    @returns:
-      C{args}, C{kwargs}
+    :returns:
+      ``args``, ``kwargs``
     """
     # This is implemented manually instead of using optparse or argparse.  We
     # do so because neither supports dynamic keyword arguments well.  Optparse
@@ -827,12 +851,12 @@ def _get_help(expr, verbosity=1):
     """
     Construct a help string.
 
-    @type expr:
-      L{UserExpr}
-    @param expr:
+    :type expr:
+      `UserExpr`
+    :param expr:
       Object to generate help for.
-    @rtype:
-      C{str}
+    :rtype:
+      ``str``
     """
     # TODO: colorize headers
     result = ""
@@ -905,7 +929,7 @@ def _handle_user_exception(exc_info=None):
     if exc_info[2].tb_next:
         exc_info = (exc_info[0], exc_info[1],
                     exc_info[2].tb_next) # skip this traceback
-    # If C{_enable_postmortem_debugger} is enabled, then debug the exception.
+    # If ``_enable_postmortem_debugger`` is enabled, then debug the exception.
     # By default, this is enabled run running in a tty.
     # We check isatty(1) here because we want 'py ... | cat' to never go into
     # the debugger.  Note that debugger() also checks whether /dev/tty is
@@ -924,22 +948,22 @@ def _handle_user_exception(exc_info=None):
 def auto_apply(function, commandline_args, namespace, arg_mode=None,
                debug=False):
     """
-    Call C{function} on command-line arguments.  Arguments can be positional
+    Call ``function`` on command-line arguments.  Arguments can be positional
     or keyword arguments like "--foo=bar".  Arguments are by default
     heuristically evaluated.
 
-    @type function:
-      C{UserExpr}
-    @param function:
+    :type function:
+      ``UserExpr``
+    :param function:
       Function to apply.
-    @type commandline_args:
-      C{list} of C{str}
-    @param commandline_args:
-      Arguments to C{function} as strings.
-    @param arg_mode:
-      How to interpret C{commandline_args}.  If C{"string"}, then treat them
-      as literal strings.  If C{"eval"}, then evaluate all arguments as
-      expressions.  If C{"auto"} (the default), then heuristically decide
+    :type commandline_args:
+      ``list`` of ``str``
+    :param commandline_args:
+      Arguments to ``function`` as strings.
+    :param arg_mode:
+      How to interpret ``commandline_args``.  If ``"string"``, then treat them
+      as literal strings.  If ``"eval"``, then evaluate all arguments as
+      expressions.  If ``"auto"`` (the default), then heuristically decide
       whether to treat as expressions or strings.
     """
     if not isinstance(function, UserExpr):
@@ -1175,7 +1199,7 @@ def SysArgvCtx(*args):
 
 def _as_filename_if_seems_like_filename(arg):
     """
-    If C{arg} seems like a filename, then return it as one.
+    If ``arg`` seems like a filename, then return it as one.
 
       >>> bool(_as_filename_if_seems_like_filename("foo.py"))
       True
@@ -1192,10 +1216,10 @@ def _as_filename_if_seems_like_filename(arg):
       >>> bool(_as_filename_if_seems_like_filename("../foo/bar-24084866"))
       True
 
-    @type arg:
-      C{str}
-    @rtype:
-      C{Filename}
+    :type arg:
+      ``str``
+    :rtype:
+      ``Filename``
     """
     try:
         filename = Filename(arg)
@@ -1358,7 +1382,7 @@ class _Namespace(object):
     def auto_eval(self, block, mode=None, info=False, auto_import=True,
                   debug=False):
         """
-        Evaluate C{block} with auto-importing.
+        Evaluate ``block`` with auto-importing.
         """
         # Equivalent to::
         #   auto_eval(arg, mode=mode, flags=FLAGS, globals=self.globals)
@@ -1473,7 +1497,7 @@ class _PyMain(object):
         m = ModuleHandle(arg)
         if m.parent:
             # Auto-import the parent, which is necessary in order to get the
-            # filename of the module.  C{ModuleHandle.filename} does this
+            # filename of the module.  ``ModuleHandle.filename`` does this
             # automatically, but we do it explicitly here so that we log
             # the import of the parent module.
             if not self.namespace.auto_import(str(m.parent.name)):
@@ -1689,7 +1713,7 @@ class _PyMain(object):
                            "arg_mode", "arg-mode", "argmode"]:
                 # Interpret --args=eval|string|auto.
                 # Note that if the user didn't specify --args, then we
-                # intentionally leave C{opts.arg_mode} set to C{None} for now,
+                # intentionally leave ``opts.arg_mode`` set to ``None`` for now,
                 # because the default varies per action.
                 del args[0]
                 self.arg_mode = _interpret_arg_mode(popvalue())

--- a/lib/python/pyflyby/_util.py
+++ b/lib/python/pyflyby/_util.py
@@ -41,7 +41,8 @@ class WrappedAttributeError(Exception):
 class cached_attribute(object):
     '''Computes attribute value and caches it in instance.
 
-    Example:
+    Example::
+
         class MyClass(object):
             @cached_attribute
             def myMethod(self):
@@ -66,7 +67,7 @@ class cached_attribute(object):
 
 def stable_unique(items):
     """
-    Return a copy of C{items} without duplicates.  The order of other items is
+    Return a copy of ``items`` without duplicates.  The order of other items is
     unchanged.
 
       >>> stable_unique([1,4,6,4,6,5,7])
@@ -89,8 +90,8 @@ def longest_common_prefix(items1, items2):
       >>> longest_common_prefix("abcde", "abcxy")
       'abc'
 
-    @rtype:
-      C{type(items1)}
+    :rtype:
+      ``type(items1)``
     """
     n = 0
     for x1, x2 in zip(items1, items2):
@@ -148,7 +149,7 @@ def NullCtx():
 @contextmanager
 def ImportPathCtx(path_additions):
     """
-    Context manager that temporarily prepends C{sys.path} with C{path_additions}.
+    Context manager that temporarily prepends ``sys.path`` with ``path_additions``.
     """
     if not isinstance(path_additions, (tuple, list)):
         path_additions = [path_additions]
@@ -196,7 +197,7 @@ def EnvVarCtx(**kwargs):
 @contextmanager
 def ExcludeImplicitCwdFromPathCtx():
     """
-    Context manager that temporarily removes "." from C{sys.path}.
+    Context manager that temporarily removes "." from ``sys.path``.
     """
     old_path = sys.path
     try:
@@ -303,7 +304,8 @@ class Aspect(object):
     "__original__" will magically be available to the wrapped function.
     This refers to the original function.
 
-    Suppose someone else wrote Foo.bar():
+    Suppose someone else wrote Foo.bar()::
+
       >>> class Foo(object):
       ...     def __init__(self, x):
       ...         self.x = x
@@ -312,7 +314,8 @@ class Aspect(object):
 
       >>> foo = Foo(42)
 
-    To monkey patch C{foo.bar}, decorate the wrapper with C{"@advise(foo.bar)"}:
+    To monkey patch ``foo.bar``, decorate the wrapper with ``"@advise(foo.bar)"``::
+
       >>> @advise(foo.bar)
       ... def addthousand(y):
       ...     return "advised foo.bar(y=%s): %s" % (y, __original__(y+1000))
@@ -320,14 +323,15 @@ class Aspect(object):
       >>> foo.bar(100)
       'advised foo.bar(y=100): bar(self.x=42,y=1100)'
 
-    You can uninstall the advice and get the original behavior back:
+    You can uninstall the advice and get the original behavior back::
+
       >>> addthousand.unadvise()
 
       >>> foo.bar(100)
       'bar(self.x=42,y=100)'
 
-    @see:
-      U{http://en.wikipedia.org/wiki/Aspect-oriented_programming}
+    :see:
+      http://en.wikipedia.org/wiki/Aspect-oriented_programming
     """
 
     _wrapper = None
@@ -466,9 +470,9 @@ class Aspect(object):
 
 def advise(joinpoint):
     """
-    Advise C{joinpoint}.
+    Advise ``joinpoint``.
 
-    See L{Aspect}.
+    See `Aspect`.
     """
     aspect = Aspect(joinpoint)
     return aspect.advise

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -93,7 +93,7 @@ class _TmpFixture(object):
     def file(self):
         """
         Single memoized new_tempfile().
-        The file is NOT under C{self.dir}.
+        The file is NOT under ``self.dir``.
         """
         return self.new_tempfile()
 
@@ -126,8 +126,8 @@ def writetext(filename, text, mode='w'):
 
 def assert_match(result, expected, ignore_prompt_number=False):
     """
-    Check that C{result} matches C{expected}.
-    C{expected} is a pattern where
+    Check that ``result`` matches ``expected``.
+    ``expected`` is a pattern where
       * "..." (three dots) matches any text (but not newline), and
       * "...." (four dots) matches any text (including newline).
     """
@@ -485,8 +485,8 @@ def _build_pythonpath(PYTHONPATH):
     """
     Build PYTHONPATH value to use.
 
-    @rtype:
-      C{str}
+    :rtype:
+      ``str``
     """
     pypath = [os.path.dirname(os.path.dirname(pyflyby.__file__))]
     pypath += _extra_readline_pythonpath_dirs()
@@ -809,7 +809,7 @@ def IPythonCtx(prog="ipython",
     """
     Spawn IPython in a pty subprocess.  Send it input and expect output.
 
-    @param frontend:
+    :param frontend:
       Which terminal frontend to use: readline (default for IPython <5) or
       prompt_toolkit (default for IPython >=5).
       IPython 4 and earlier only support readline.
@@ -1210,7 +1210,7 @@ def IPythonNotebookCtx(**kwargs):
 
 def _wait_for_output(child, timeout):
     """
-    Wait up to C{timeout} seconds for output.
+    Wait up to ``timeout`` seconds for output.
     """
     # In IPython 5, we cannot send any output before IPython responds to the
     # tab, else it won't respond to the tab.  The purpose of this function is
@@ -1218,7 +1218,7 @@ def _wait_for_output(child, timeout):
     if DEBUG:
         print("_wait_for_output()")
     got_data_already = False
-    # Read C{BLOCKSIZE} bytes at a time.  Note that currently our ansi filter
+    # Read ``BLOCKSIZE`` bytes at a time.  Note that currently our ansi filter
     # won't work across block boundaries, so currently this blocksize needs to
     # be large enough that we don't span an ANSI sequence across two blocks.
     BLOCKSIZE = 16*4096

--- a/tests/test_livepatch.py
+++ b/tests/test_livepatch.py
@@ -1276,7 +1276,7 @@ def test_xreload_module_hook_1(tpp):
         def a(): return 1000
         def b(): return 2000
         def __livepatch__(old, new):
-            # Selectively update C{a} but not C{b}
+            # Selectively update ``a`` but not ``b``
             from pyflyby import livepatch
             livepatch(old.a, new.a)
             old.b = new.b
@@ -1338,8 +1338,8 @@ def test_xreload_module_hook_update_parameters_reordered_1(tpp):
 
 
 def test_xreload_module_hook_return_new_1(tpp):
-    # Verify behavior of a module-level hook that returns C{new} instead of
-    # C{old}.
+    # Verify behavior of a module-level hook that returns ``new`` instead of
+    # ``old``.
     writetext(tpp/"devastation69918044.py", """
         def homeless(): return 17436793
     """)

--- a/tests/test_py.py
+++ b/tests/test_py.py
@@ -93,8 +93,8 @@ def _build_pythonpath(PYTHONPATH):
     """
     Build PYTHONPATH value to use.
 
-    @rtype:
-      C{str}
+    :rtype:
+      ``str``
     """
     pypath = [os.path.dirname(os.path.dirname(pyflyby.__file__))]
     if isinstance(PYTHONPATH, (Filename,) + string_types):
@@ -118,7 +118,7 @@ def _py_internal_1(args, stdin="",
 
 def py(*args, **kwargs):
     """
-    Run C{py} and return stdout.
+    Run ``py`` and return stdout.
     """
     if len(args) == 1 and isinstance(args[0], (tuple, list)):
         args = tuple(args[0])
@@ -1633,7 +1633,7 @@ def test_join_single_arg_1():
 
 def test_join_single_arg_fallback_1():
     # Verify that when heuristically joining, we fall back to heuristic apply.
-    # Even though "print foo" is parsable as a joined string, if C{foo} is not
+    # Even though "print foo" is parsable as a joined string, if ``foo`` is not
     # importable, then fallback to "print('foo')".
     result = py("print", "ardmore23653526")
     expected = dedent("""

--- a/tests/xrefs.py
+++ b/tests/xrefs.py
@@ -1,6 +1,6 @@
 """
 Blah.
-L{undefined_xref_from_module}
+`undefined_xref_from_module`
 
 """
 
@@ -16,41 +16,41 @@ from __future__ import (absolute_import, division, print_function,
 class FooClass(object):
     """
     Blah.
-    L{undefined_xref_from_class}
+    `undefined_xref_from_class`
     """
 
     foo_attribute = 123
     """
     Blah.
-    L{undefined_xref_from_class_attribute}
+    `undefined_xref_from_class_attribute`
     """
 
     def foo_method(self):
         """
         Blah.
-        L{undefined_xref_from_method}
+        `undefined_xref_from_method`
         """
 
     @staticmethod
     def foo_wrapped_method(abc, *args, **kwargs):
         """
         Blah.
-        L{undefined_xref_from_wrapped_method}
+        `undefined_xref_from_wrapped_method`
 
-        @param abc:
-          L{undefined_xref_from_param}
-        @type abc:
-          L{undefined_xref_from_type}
-        @param args:
-          L{undefined_xref_from_args_param}
-        @type args:
-          L{undefined_xref_from_args_type}
-        @param kwargs:
-          L{undefined_xref_from_kwargs_param}
-        @type kwargs:
-          L{undefined_xref_from_kwargs_type}
-        @rtype:
-          L{undefined_xref_from_rtype}
+        :param abc:
+          `undefined_xref_from_param`
+        :type abc:
+          `undefined_xref_from_type`
+        :param args:
+          `undefined_xref_from_args_param`
+        :type args:
+          `undefined_xref_from_args_type`
+        :param kwargs:
+          `undefined_xref_from_kwargs_param`
+        :type kwargs:
+          `undefined_xref_from_kwargs_type`
+        :rtype:
+          `undefined_xref_from_rtype`
         """
 
     @property
@@ -58,39 +58,39 @@ class FooClass(object):
         """
         Blah.
 
-        L{undefined_xref_from_property}
+        `undefined_xref_from_property`
 
-        @rtype:
-          L{undefined_xref_from_property_rtype}
+        :rtype:
+          `undefined_xref_from_property_rtype`
         """
 
     def __foo_private_method(self):
         """
         Blah.
 
-        L{undefined_xref_from_private_method}
+        `undefined_xref_from_private_method`
         """
 
 def foo_global_function():
     """
     Blah.
-    L{undefined_xref_from_global_function}
+    `undefined_xref_from_global_function`
     """
 
 foo_module_attribute = 123
 """
 Blah.
-L{undefined_xref_from_module_attribute}
+`undefined_xref_from_module_attribute`
 """
 
 foo_module_attribute_2 = 123
 """
-Blah L{undefined_xref_from_module_attribute_first_paragraph}.
+Blah `undefined_xref_from_module_attribute_first_paragraph`.
 """
 
 foo_indexed = 123
 """
 Blah.
 
-L{undefined_xref_extern_a <dummy_module1.undefined_xref_extern_b>}
+`undefined_xref_extern_a <dummy_module1.undefined_xref_extern_b>`
 """


### PR DESCRIPTION
epytext in docstrings & comments of .py source code files are now
converted to reST.

Reason for conversion:
----------------------

Epydoc has been discontinued and is unmaintained since 2008.
Also, it doesn't seem to suport Python 3. Therefore, we wanted
to migrate existing epytext in source code.

OTOH Python documentation is itself generated via sphinx.
Sphinx and the supported reST markups, roles & directives
provide a lot of configuration & formatting options that
weren't available or straight forward to achieve using
epydoc.

Since we wish to proceed with auto generating the docs,
we wanted to modify the epytext to reST in source code as
a first step.

Few points to note:
-------------------

- sphinx-build consumes a .rst file to generate the docs.
  Therefore, sphinx-apidoc is to be run on the source code
  to generate the required rst and sphinx-build can then
  build the docs using the same.

- The utility used for replacement of epytext to reST converts
  the references L{text} to `text`, i.e., it replaces it with
  default role.
  To make sure the sphinx build creates actual reference for
  the specified text please specify below configuration in
  conf.py file:

	default_role="py:obj"

- At times sphinx complains if it finds multiple targets for a
  given reference. And the docs ends with no link for the text.
  Ex:

	 <filename>:docstring of <module>:: WARNING:
	 more than one target found for cross-reference
	 u'ImportSet': xyz.ImportSet, abc.def.ImportSet,...

  This can be fixed by either

	 - specifying the fully qualified name of the text or
	 - writing a custom extension that identifies the right target

- Code section have a newline prepended else sphinx complains.

Minor points:
-------------

- L{text} followed by a aplhanumeric character is replaced with
  `text`<space>alphanumeric charcter.
  Ex: L{ImportSet}s => `ImportSet` s
  This is done to make sure sphinx doesn't complain.
  If needed we can replace the space with '\'.

Also, some minor manual edits were made to fix indentation issues
at few places.

Ref      : Prop#221874,https://github.com/pyflyby/pyflyby/issues/40
Reviewer : lalchang