### PR TITLE
Ignore doctest options in get_doctests()

### DIFF
--- a/lib/python/pyflyby/_parse.py
+++ b/lib/python/pyflyby/_parse.py
@@ -7,6 +7,7 @@ from __future__ import (absolute_import, division, print_function,
 
 import ast
 from   collections              import namedtuple
+from   doctest                  import DocTestParser
 from   functools                import total_ordering
 from   itertools                import groupby
 import re
@@ -1272,8 +1273,7 @@ class PythonBlock(object):
         :rtype:
           ``list`` of `PythonStatement` s
         """
-        import doctest
-        parser = doctest.DocTestParser()
+        parser = IgnoreOptionsDocTestParser()
         doctest_blocks = []
         filename = self.filename
         flags = self.flags
@@ -1348,3 +1348,10 @@ class PythonBlock(object):
         h = hash((self.text, self.flags))
         self.__hash__ = lambda: h
         return h
+
+class IgnoreOptionsDocTestParser(DocTestParser):
+    def _find_options(self, source, name, lineno):
+        # Ignore doctest options. We don't use them, and we don't want to
+        # error on unknown options, which is what the default DocTestParser
+        # does.
+        return {}

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -925,6 +925,18 @@ def test_PythonBlock_doctest_with_1():
     expected = (PythonStatement("with 11:\n  22\n", startpos=(5, 11)),)
     assert doctest_block.statements == expected
 
+def test_PythonBlock_doctest_ignore_doctest_options_1():
+    block = PythonBlock(dedent('''
+        def foo():
+            """
+            >>> 123 # doctest:+FOOBAR
+            """
+    '''))
+    doctest_blocks = block.get_doctests()
+    doctest_block, = doctest_blocks
+    expected = (PythonStatement("123 # doctest:+FOOBAR\n", startpos=(4, 9)),)
+    assert doctest_block.statements == expected
+
 
 @pytest.mark.skipif(
     sys.version_info < (2,7),


### PR DESCRIPTION
They aren't used anyway, and it causes it to give a warning for unknown
options, meaning they cannot be supported.

Fixes #54.