### PR TITLE
Fix import statement passed to post_import_hook

### DIFF
--- a/lib/python/pyflyby/_autoimp.py
+++ b/lib/python/pyflyby/_autoimp.py
@@ -1627,7 +1627,7 @@ def auto_import_symbol(fullname, namespaces, db=None, autoimported=None, post_im
                 autoimported[DottedIdentifier(fullname)] = False
                 return False
             # Succeeded.
-            successful_import = str(imp)
+            successful_import = imp
             autoimported[DottedIdentifier(imp.import_as)] = True
             if imp.import_as == fullname:
                 if post_import_hook:
@@ -1668,7 +1668,7 @@ def auto_import_symbol(fullname, namespaces, db=None, autoimported=None, post_im
         if not result:
             return False
         else:
-          successful_import = imp_stmt
+            successful_import = Import(imp_stmt)
     if post_import_hook and successful_import:
         post_import_hook(successful_import)
     return True

--- a/tests/test_autoimp.py
+++ b/tests/test_autoimp.py
@@ -1864,3 +1864,35 @@ def test_auto_import_nameerror_1(tpp, capsys):
         Traceback (most recent call last):
     """).lstrip()
     assert out.startswith(expected)
+
+
+def test_post_import_hook_incomplete_import():
+    db = ImportDB('import glob')
+    expected = Import('import glob')
+    def test_hook(val):
+        assert val == expected
+    auto_import("glob.glob('*')", [{}], db=db, post_import_hook=test_hook)
+
+
+def test_post_import_hook_alias_import():
+    db = ImportDB('import numpy as np')
+    expected = Import('import numpy as np')
+    def test_hook(val):
+        assert val == expected
+    auto_import("np", [{}], db=db, post_import_hook=test_hook)
+
+
+def test_post_import_hook_from_statement():
+    db = ImportDB('from numpy import compat')
+    expected = Import('from numpy import compat')
+    def test_hook(val):
+        assert val == expected
+    auto_import("compat", [{}], db=db, post_import_hook=test_hook)
+
+
+def test_post_import_hook_fullname():
+    db = ImportDB('import numpy.compat')
+    expected = Import('import numpy.compat')
+    def test_hook(val):
+        assert val == expected
+    auto_import("numpy.compat", [{}], db=db, post_import_hook=test_hook)


### PR DESCRIPTION
When post_import_hook is executed in auto_import_symbol
method, import statement passed to it should be the last
successfully executed import statement

For example,
\>>> glob.glob('*')
[PYFLYBY] import glob

Before this change -
post_import_hook('import glob.glob')

After this change -
post_import_hook('import glob')