### PR TITLE
Remove set -x from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
   - pip list
 
 script:
-  - set -x
+  # - set -x
   - shopt -s extglob globstar
   # pyflakes all files except for known_imports/*, etc/*, and __init__.py,
   # which are all unused imports. We use flake8 so we can use noqa if

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ script:
   # Python version)
   - python -We:invalid -m compileall -f -q lib/ etc/;
   - export DEBUG_TEST_PYFLYBY=1
-  - pytest --doctest-modules lib tests
+  - pytest -v --doctest-modules lib tests
   # Smoke test tidy-imports on the codebase. This only fails if there is an
   # exception from a bug, but we could also make it fail if there are imports
   # that need to be tidied.


### PR DESCRIPTION
This makes the output a bit too verbose, and it's only really useful for
debugging issues with the Travis config itself.