### PR TITLE
Add a --symlinks flag to tidy-imports to modify how symlinks are handled

### DIFF
--- a/lib/python/pyflyby/_cmdline.py
+++ b/lib/python/pyflyby/_cmdline.py
@@ -159,7 +159,7 @@ def parse_args(addopts=None, import_format_params=False, modify_action_params=Fa
 
         parser.add_option(
             '--symlinks', action='callback', nargs=1, type=str,
-            dest='symlinks', callback=symlink_callback, help=symlinks_help,
+            dest='symlinks', callback=symlink_callback, help="--symlinks should be one of: " + symlinks_help,
         )
         parser.set_defaults(symlinks='error')
 
@@ -464,8 +464,6 @@ def symlink_callback(option, opt_str, value, parser):
         raise optparse.OptionValueError("--symlinks must be one of 'error', 'follow', 'skip', or 'replace'. Got %r" % value)
 
 symlinks_help = """\
---symlinks should be one of:
-
 --symlinks=error (default; gives an error on symlinks),
 --symlinks=follow (follows symlinks),
 --symlinks=skip (skips symlinks),
@@ -477,7 +475,7 @@ symlinks_help = """\
 def symlink_error(m):
     if m.filename.islink:
         raise SystemExit("""\
-%s appears to be a symlink. Use one of the following options to allow symlinks:
+Error: %s appears to be a symlink. Use one of the following options to allow symlinks:
 %s
 """ % (m.filename, indent(symlinks_help, '    ')))
 

--- a/lib/python/pyflyby/_cmdline.py
+++ b/lib/python/pyflyby/_cmdline.py
@@ -12,7 +12,7 @@ import six
 from   six                      import reraise
 from   six.moves                import input
 import sys
-from   textwrap                 import dedent
+from   textwrap                 import dedent, indent
 import traceback
 
 
@@ -157,6 +157,12 @@ def parse_args(addopts=None, import_format_params=False, modify_action_params=Fa
         parser.set_default('actions', tuple(default_actions))
         parser.add_option_group(group)
 
+        parser.add_option(
+            '--symlinks', action='callback', nargs=1, type=str,
+            dest='symlinks', callback=symlink_callback, help=symlinks_help,
+        )
+        parser.set_defaults(symlinks='error')
+
     if import_format_params:
         group = optparse.OptionGroup(parser, "Pretty-printing options")
         group.add_option('--align-imports', '--align', type='str', default="32",
@@ -236,7 +242,13 @@ def parse_args(addopts=None, import_format_params=False, modify_action_params=Fa
         parser.add_option_group(group)
     if addopts is not None:
         addopts(parser)
-    options, args = parser.parse_args()
+    # This is the only way to provide a default value for an option with a
+    # callback.
+    if modify_action_params:
+        args = ["--symlinks=error"] + sys.argv[1:]
+    else:
+        args = None
+    options, args = parser.parse_args(args=args)
     if import_format_params:
         align_imports_args = [int(x.strip())
                               for x in options.align_imports.split(",")]
@@ -442,3 +454,51 @@ def action_query(prompt="Proceed?"):
         print("Aborted")
         raise AbortActions
     return action
+
+def symlink_callback(option, opt_str, value, parser):
+    parser.values.actions = tuple(i for i in parser.values.actions if i not in
+    symlink_callbacks.values())
+    if value in symlink_callbacks:
+        parser.values.actions = (symlink_callbacks[value],) + parser.values.actions
+    else:
+        raise optparse.OptionValueError("--symlinks must be one of 'error', 'follow', 'skip', or 'replace'. Got %r" % value)
+
+symlinks_help = """\
+--symlinks should be one of:
+
+--symlinks=error (default; gives an error on symlinks),
+--symlinks=follow (follows symlinks),
+--symlinks=skip (skips symlinks),
+--symlinks=replace (replaces symlinks with the target file\
+"""
+
+# Warning, the symlink actions will only work if they are run first.
+# Otherwise, output_content may already be cached
+def symlink_error(m):
+    if m.filename.islink:
+        raise SystemExit("""\
+%s appears to be a symlink. Use one of the following options to allow symlinks:
+%s
+""" % (m.filename, indent(symlinks_help, '    ')))
+
+def symlink_follow(m):
+    if m.filename.islink:
+        logger.info("Following symlink %s" % m.filename)
+        m.filename = m.filename.realpath
+
+def symlink_skip(m):
+    if m.filename.islink:
+        logger.info("Skipping symlink %s" % m.filename)
+        raise AbortActions
+
+def symlink_replace(m):
+    if m.filename.islink:
+        logger.info("Replacing symlink %s" % m.filename)
+        # The current behavior automatically replaces symlinks, so do nothing
+
+symlink_callbacks = {
+    'error': symlink_error,
+    'follow': symlink_follow,
+    'skip': symlink_skip,
+    'replace': symlink_replace,
+}

--- a/lib/python/pyflyby/_cmdline.py
+++ b/lib/python/pyflyby/_cmdline.py
@@ -473,6 +473,8 @@ symlinks_help = """\
 # Warning, the symlink actions will only work if they are run first.
 # Otherwise, output_content may already be cached
 def symlink_error(m):
+    if m.filename == Filename.STDIN:
+        return symlink_follow(m)
     if m.filename.islink:
         raise SystemExit("""\
 Error: %s appears to be a symlink. Use one of the following options to allow symlinks:
@@ -480,16 +482,22 @@ Error: %s appears to be a symlink. Use one of the following options to allow sym
 """ % (m.filename, indent(symlinks_help, '    ')))
 
 def symlink_follow(m):
+    if m.filename == Filename.STDIN:
+        return
     if m.filename.islink:
         logger.info("Following symlink %s" % m.filename)
         m.filename = m.filename.realpath
 
 def symlink_skip(m):
+    if m.filename == Filename.STDIN:
+        return symlink_follow(m)
     if m.filename.islink:
         logger.info("Skipping symlink %s" % m.filename)
         raise AbortActions
 
 def symlink_replace(m):
+    if m.filename == Filename.STDIN:
+        return symlink_follow(m)
     if m.filename.islink:
         logger.info("Replacing symlink %s" % m.filename)
         # The current behavior automatically replaces symlinks, so do nothing

--- a/lib/python/pyflyby/_cmdline.py
+++ b/lib/python/pyflyby/_cmdline.py
@@ -12,7 +12,7 @@ import six
 from   six                      import reraise
 from   six.moves                import input
 import sys
-from   textwrap                 import dedent, indent
+from   textwrap                 import dedent
 import traceback
 
 
@@ -20,7 +20,7 @@ from   pyflyby._file            import (FileText, Filename, atomic_write_file,
                                         expand_py_files_from_args, read_file)
 from   pyflyby._importstmt      import ImportFormatParams
 from   pyflyby._log             import logger
-from   pyflyby._util            import cached_attribute
+from   pyflyby._util            import cached_attribute, indent
 
 
 def hfmt(s):

--- a/lib/python/pyflyby/_file.py
+++ b/lib/python/pyflyby/_file.py
@@ -115,8 +115,16 @@ class Filename(object):
         return type(self)(os.path.realpath(self._filename))
 
     @property
+    def realpath(self):
+        return type(self)(os.path.realpath(self._filename))
+
+    @property
     def exists(self):
         return os.path.exists(self._filename)
+
+    @property
+    def islink(self):
+        return os.path.islink(self._filename)
 
     @property
     def isdir(self):

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -481,3 +481,167 @@ def test_tidy_imports_py3_fallback():
         assert b"SyntaxError detected, falling back" in proc_output
     else:
         assert b"SyntaxError detected, falling back" not in proc_output
+
+def test_tidy_imports_symlinks_default():
+    input = dedent('''
+        import x
+    ''')
+    with tempfile.NamedTemporaryFile(suffix=".py", mode='w+') as f:
+        f.write(input)
+        f.flush()
+        head, tail = os.path.split(f.name)
+        symlink_name = os.path.join(head, 'symlink-' + tail)
+        os.symlink(f.name, symlink_name)
+        child = pexpect.spawn(BIN_DIR+'/tidy-imports', [symlink_name], timeout=5.0)
+        child.logfile = BytesIO()
+        # child.expect_exact(" [y/N]")
+        # child.send("n\n")
+        child.expect(pexpect.EOF)
+        assert not os.path.islink(f.name)
+        assert os.path.islink(symlink_name)
+        with open(f.name) as f2:
+            output = f2.read()
+        with open(symlink_name) as f2:
+            symlink_output = f2.read()
+
+    proc_output = child.logfile.getvalue()
+    assert b"Error: %s appears to be a symlink" % symlink_name.encode("utf-8") in proc_output
+    assert output == input
+    assert symlink_output == input
+
+
+def test_tidy_imports_symlinks_error():
+    input = dedent('''
+        import x
+    ''')
+    with tempfile.NamedTemporaryFile(suffix=".py", mode='w+') as f:
+        f.write(input)
+        f.flush()
+        head, tail = os.path.split(f.name)
+        symlink_name = os.path.join(head, 'symlink-' + tail)
+        os.symlink(f.name, symlink_name)
+        child = pexpect.spawn(BIN_DIR+'/tidy-imports', ['--symlinks=error', symlink_name], timeout=5.0)
+        child.logfile = BytesIO()
+        # child.expect_exact(" [y/N]")
+        # child.send("n\n")
+        child.expect(pexpect.EOF)
+        assert not os.path.islink(f.name)
+        assert os.path.islink(symlink_name)
+        with open(f.name) as f2:
+            output = f2.read()
+        with open(symlink_name) as f2:
+            symlink_output = f2.read()
+
+    proc_output = child.logfile.getvalue()
+    assert b"Error: %s appears to be a symlink" % symlink_name.encode("utf-8") in proc_output
+    assert output == input
+    assert symlink_output == input
+
+def test_tidy_imports_symlinks_follow():
+    input = dedent('''
+        import x
+    ''')
+    with tempfile.NamedTemporaryFile(suffix=".py", mode='w+') as f:
+        f.write(input)
+        f.flush()
+        head, tail = os.path.split(f.name)
+        symlink_name = os.path.join(head, 'symlink-' + tail)
+        os.symlink(f.name, symlink_name)
+        child = pexpect.spawn(BIN_DIR+'/tidy-imports', ['--symlinks=follow', symlink_name], timeout=5.0)
+        child.logfile = BytesIO()
+        child.expect_exact(" [y/N]")
+        child.send("y\n")
+        child.expect(pexpect.EOF)
+        assert not os.path.islink(f.name)
+        assert os.path.islink(symlink_name)
+        with open(f.name) as f2:
+            output = f2.read()
+        with open(symlink_name) as f2:
+            symlink_output = f2.read()
+
+    proc_output = child.logfile.getvalue()
+    assert b"Following symlink %s" % symlink_name.encode("utf-8") in proc_output
+    assert 'import x' not in output
+    assert 'import x' not in symlink_output
+
+def test_tidy_imports_symlinks_skip():
+    input = dedent('''
+        import x
+    ''')
+    with tempfile.NamedTemporaryFile(suffix=".py", mode='w+') as f:
+        f.write(input)
+        f.flush()
+        head, tail = os.path.split(f.name)
+        symlink_name = os.path.join(head, 'symlink-' + tail)
+        os.symlink(f.name, symlink_name)
+        child = pexpect.spawn(BIN_DIR+'/tidy-imports', ['--symlinks=skip',
+                                                        symlink_name], timeout=5.0)
+        child.logfile = BytesIO()
+        # child.expect_exact(" [y/N]")
+        # child.send("n\n")
+        child.expect(pexpect.EOF)
+        assert not os.path.islink(f.name)
+        assert os.path.islink(symlink_name)
+        with open(f.name) as f2:
+            output = f2.read()
+        with open(symlink_name) as f2:
+            symlink_output = f2.read()
+
+    proc_output = child.logfile.getvalue()
+    assert b"Skipping symlink %s" % symlink_name.encode("utf-8") in proc_output
+    assert output == input
+    assert symlink_output == input
+
+def test_tidy_imports_symlinks_replace():
+    input = dedent('''
+        import x
+    ''')
+    with tempfile.NamedTemporaryFile(suffix=".py", mode='w+') as f:
+        f.write(input)
+        f.flush()
+        head, tail = os.path.split(f.name)
+        symlink_name = os.path.join(head, 'symlink-' + tail)
+        os.symlink(f.name, symlink_name)
+        child = pexpect.spawn(BIN_DIR+'/tidy-imports', ['--symlink=replace', symlink_name], timeout=5.0)
+        child.logfile = BytesIO()
+        child.expect_exact(" [y/N]")
+        child.send("y\n")
+        child.expect(pexpect.EOF)
+        assert not os.path.islink(f.name)
+        assert not os.path.islink(symlink_name)
+        with open(f.name) as f2:
+            output = f2.read()
+        with open(symlink_name) as f2:
+            symlink_output = f2.read()
+
+    proc_output = child.logfile.getvalue()
+    assert b"Replacing symlink %s" % symlink_name.encode("utf-8") in proc_output
+    assert output == input
+    assert 'import x' not in symlink_output
+
+def test_tidy_imports_symlinks_bad_argument():
+    input = dedent('''
+        import x
+    ''')
+    with tempfile.NamedTemporaryFile(suffix=".py", mode='w+') as f:
+        f.write(input)
+        f.flush()
+        head, tail = os.path.split(f.name)
+        symlink_name = os.path.join(head, 'symlink-' + tail)
+        os.symlink(f.name, symlink_name)
+        child = pexpect.spawn(BIN_DIR+'/tidy-imports', ['--symlinks=bad', symlink_name], timeout=5.0)
+        child.logfile = BytesIO()
+        # child.expect_exact(" [y/N]")
+        # child.send("n\n")
+        child.expect(pexpect.EOF)
+        assert not os.path.islink(f.name)
+        assert os.path.islink(symlink_name)
+        with open(f.name) as f2:
+            output = f2.read()
+        with open(symlink_name) as f2:
+            symlink_output = f2.read()
+
+    proc_output = child.logfile.getvalue()
+    assert b"error: --symlinks must be one of" in proc_output
+    assert output == input
+    assert symlink_output == input


### PR DESCRIPTION
The default is now to error on a symlink (previously, it would replace
symlinks). --symlinks can also be set to skip, follow, or replace.

Still needs tests.

Fixes #22.